### PR TITLE
Add mock mode, VO exam history & comparison, image tools and green theme (frontend only)

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
+VITE_USE_MOCKS=true
 VITE_API_URL=http://localhost:8000
-VITE_WEBSOCKET_URL=ws://localhost:8000/ws/
+VITE_WEBSOCKET_URL=ws://localhost:8000/

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Backoffice from "./pages/BackOffice";
 import Reports from "./pages/Reports";
 import Records from "./pages/Records";
 import AnalysisReview from "./pages/AnalysisReview";
+import CompareExams from "./pages/CompareExams";
 
 function Logout() {
   localStorage.clear();
@@ -37,6 +38,7 @@ function App() {
             <Route path="/records" element={<ProtectedRoute><Records/></ProtectedRoute>} />
             <Route path="/select_echo" element={<ProtectedRoute><ManualAnnotationSetup/></ProtectedRoute>} />
             <Route path="/analyse_aortic_valve/:patientId/:echoId" element={<ProtectedRoute><ManualAnnotation/></ProtectedRoute>} />
+            <Route path="/patients/:patientId/compare/:examIdA/:examIdB" element={<ProtectedRoute><CompareExams/></ProtectedRoute>} />
             <Route path="/analysis_review" element={<ProtectedRoute><AnalysisReview/></ProtectedRoute>} />
             <Route path="/backoffice" element={<ProtectedRoute><Backoffice></Backoffice></ProtectedRoute>} />
             <Route path="/reports" element={<ProtectedRoute><Reports></Reports></ProtectedRoute>} />

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,101 +1,164 @@
-import axios from "axios"
-import { ACCESS_TOKEN } from "./constants"
+import axios from "axios";
+import { ACCESS_TOKEN } from "./constants";
+import { mockApi, mockDb } from "./mocks/mockDb";
 
-const api = axios.create({
-    baseURL: import.meta.env.VITE_API_URL,
-});
+const useMocks = import.meta.env.VITE_USE_MOCKS === "true";
 
-// Interceptor para adicionar o token de autenticação antes de cada requisição
-api.interceptors.request.use(
+const api = useMocks
+  ? mockApi
+  : axios.create({
+      baseURL: import.meta.env.VITE_API_URL,
+    });
+
+if (!useMocks) {
+  // Interceptor para adicionar o token de autenticação antes de cada requisição
+  api.interceptors.request.use(
     (config) => {
-        const token = localStorage.getItem(ACCESS_TOKEN);
-        if(token) {
-            config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
+      const token = localStorage.getItem(ACCESS_TOKEN);
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
     },
-    (error) => {
-        return Promise.reject(error);
-    }
-)
+    (error) => Promise.reject(error)
+  );
+}
 
-
-export const getPatients = async (params) => { // params é passado para filtrar os pacientes
-    try {
-        const response = await api.get('/api/patients/', { params });
-        return response.data;
-    } catch (error) {
-        console.error("Error fetching patients:", error);
-        throw error;
+export const getPatients = async (params) => {
+  // params é passado para filtrar os pacientes
+  try {
+    if (useMocks) {
+      return mockDb.getPatients();
     }
+    const response = await api.get("/api/patients/", { params });
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching patients:", error);
+    throw error;
+  }
 };
 
 export const getReports = async (patientId) => {
-    try {
-        const response = await api.get(`/api/reports/${patientId}/`);
-        return response.data;
-    } catch (error) {
-        console.error("Error fetching reports:", error);
-        throw error;
+  try {
+    if (useMocks) {
+      return mockDb.getReports(patientId);
     }
+    const response = await api.get(`/api/reports/${patientId}/`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching reports:", error);
+    throw error;
+  }
 };
 
 export const deletePatient = async (patientId) => {
-    try {
-        const response = await api.delete(`/api/patient/${patientId}/delete/`);
-        return response.data;
-    } catch (error) {
-        console.error("Error deleting patient:", error);
-        throw error;
+  try {
+    if (useMocks) {
+      mockDb.deletePatient(patientId);
+      return { ok: true };
     }
-}
+    const response = await api.delete(`/api/patient/${patientId}/delete/`);
+    return response.data;
+  } catch (error) {
+    console.error("Error deleting patient:", error);
+    throw error;
+  }
+};
 
 export const deleteReport = async (reportId) => {
-    try {
-        const response = await api.delete(`/api/report/${reportId}/delete/`)
-        return response.data;
-    } catch {
-        console.error("Error deleteing report:", error);
-        throw error;
+  try {
+    if (useMocks) {
+      mockDb.deleteReport(reportId);
+      return { ok: true };
     }
-}
+    const response = await api.delete(`/api/report/${reportId}/delete/`);
+    return response.data;
+  } catch (error) {
+    console.error("Error deleteing report:", error);
+    throw error;
+  }
+};
 
 export const getEchoResults = async (patientId) => {
-    try {
-        const response = await api.get(`/api/patient/${patientId}/echodata/`);
-        return response.data;
-    } catch (error) {
-        console.error("Error fetching echo results:", error);
-        throw error;
+  try {
+    if (useMocks) {
+      return mockDb.getEchoResults(patientId);
     }
-}
+    const response = await api.get(`/api/patient/${patientId}/echodata/`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching echo results:", error);
+    throw error;
+  }
+};
 
 export const createPatient = async (patientData) => {
-    try {
-        let config = {};
-        if (patientData instanceof FormData) {
-            config.headers = { "Content-Type": "multipart/form-data" };
-        }
-        const response = await api.post('/api/patient/create/', patientData, config);
-        return response.data;
-    } catch (error) {
-        console.error("Error creating patient:", error);
-        throw error;
+  try {
+    if (useMocks) {
+      return mockDb.createPatient(patientData);
     }
+    let config = {};
+    if (patientData instanceof FormData) {
+      config.headers = { "Content-Type": "multipart/form-data" };
+    }
+    const response = await api.post("/api/patient/create/", patientData, config);
+    return response.data;
+  } catch (error) {
+    console.error("Error creating patient:", error);
+    throw error;
+  }
 };
 
 export const createReport = async (formData, patientId) => {
-    try {
-        let config = {};
-        if (formData instanceof FormData) {
-            config.headers = { "Content-Type": "multipart/form-data" };
-        }
-        const response = await api.post(`/api/reports/${patientId}/create/`, formData, config);
-        return response.data;
-    } catch (error) {
-        console.error("Error creating report:", error);
-        throw error;
+  try {
+    if (useMocks) {
+      const reportText = formData instanceof FormData ? formData.get("reportText") : formData?.reportText;
+      return mockDb.createReport({ patientId, reportText: reportText || "" });
     }
-}
+    let config = {};
+    if (formData instanceof FormData) {
+      config.headers = { "Content-Type": "multipart/form-data" };
+    }
+    const response = await api.post(`/api/reports/${patientId}/create/`, formData, config);
+    return response.data;
+  } catch (error) {
+    console.error("Error creating report:", error);
+    throw error;
+  }
+};
+
+export const getPatientExams = async (patientId) => {
+  if (useMocks) {
+    return mockDb.getPatientExams(patientId);
+  }
+  const patients = await getPatients();
+  const patient = patients.find((item) => item.id === Number(patientId));
+  return patient?.echocardiograms || [];
+};
+
+export const getExamSettings = async (examId) => {
+  if (useMocks) {
+    return mockDb.getExamSettings(examId);
+  }
+  const cached = localStorage.getItem(`exam-settings-${examId}`);
+  if (cached) {
+    return JSON.parse(cached);
+  }
+  return null;
+};
+
+export const updateExamSettings = async (examId, updates) => {
+  if (useMocks) {
+    return mockDb.updateExamSettings(examId, updates);
+  }
+  const next = {
+    ...(await getExamSettings(examId)),
+    ...updates,
+  };
+  localStorage.setItem(`exam-settings-${examId}`, JSON.stringify(next));
+  return next;
+};
+
+export const useMockApi = useMocks;
 
 export default api;

--- a/frontend/src/components/AnnotationDropdown.jsx
+++ b/frontend/src/components/AnnotationDropdown.jsx
@@ -11,7 +11,7 @@ export default function AnnotationDropdown({ children, handleDectectValve, toggl
             <DropdownMenu.Portal className="rounded-b-sm shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]">
                 <DropdownMenu.Content className="bg-white min-w-30 w-55 p-1 space-y-1" align="start" sideOffset={5}>
                     <DropdownMenu.Item 
-                        className="group p-2 pl-4 rounded-sm flex items-center gap-4 relative select-none leading-none text-gray-dark outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-red data-[disabled]:text-gray-dark data-[highlighted]:text-white cursor-pointer"
+                        className="group p-2 pl-4 rounded-sm flex items-center gap-4 relative select-none leading-none text-gray-dark outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-green data-[disabled]:text-gray-dark data-[highlighted]:text-white cursor-pointer"
                         onClick={handleDectectValve}
                         title="AI Valve Detection Tool"
                     >
@@ -19,7 +19,7 @@ export default function AnnotationDropdown({ children, handleDectectValve, toggl
                         <span role='tooltip'>AI Detection</span>
                     </DropdownMenu.Item>
                     <DropdownMenu.Item 
-                        className="group p-2 pl-4 rounded-sm flex items-center gap-4 relative select-none leading-none text-gray-dark outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-red data-[disabled]:text-gray-medium data-[highlighted]:text-white cursor-pointer"
+                        className="group p-2 pl-4 rounded-sm flex items-center gap-4 relative select-none leading-none text-gray-dark outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-green data-[disabled]:text-gray-medium data-[highlighted]:text-white cursor-pointer"
                         onClick={toggleDrawingMode}
                         disabled={annotated}
                         title="Aortic Valve Segmentation"

--- a/frontend/src/components/AnnotationTool.jsx
+++ b/frontend/src/components/AnnotationTool.jsx
@@ -9,7 +9,7 @@ import ProgressBar from "./ProgressBar";
 import AnnotationDropdown from "./AnnotationDropdown";
 import { useUnsavedStore } from "../store/useUnsavedStore";
 
-export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, rects, setRects, calcificationStatus, setCalcificationStatus, predictedValveBoxes, setPredictedValveBoxes, calcification, setCalcification, predictionHistory, setPredictionHistory }) {
+export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, rects, setRects, calcificationStatus, setCalcificationStatus, predictedValveBoxes, setPredictedValveBoxes, calcification, setCalcification, predictionHistory, setPredictionHistory, imageSettings, onImageSettingsChange }) {
     const [frame] = useImage(frames[currentFrame]?.url)
     // Referências ao stage (a área de desenho) e ao group (o conjunto da imagem com as anotações)
     const stageRef = useRef(null);
@@ -32,6 +32,11 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
 
     // Controla qual é o tipo de ponteiro do rato com base no que o utilizador está a fazer
     const [cursorType, setCursorType] = useState('default');
+
+    const brightness = imageSettings?.brightness ?? 1;
+    const contrast = imageSettings?.contrast ?? 1;
+    const blur = imageSettings?.blur ?? 0;
+    const zoom = imageSettings?.zoom ?? 1;
 
     // Um hook personalizado para iniciar a identificação da válvula de UMA ÚNICA imagem
     const { progress: valveProgress, isLoading: isLoadingValve, startDetection: startSingleDetection, cancelDetection: cancelSingleDetection } = useValveDetection();
@@ -85,6 +90,12 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
             });
         }
     }, [frame, currentFrame]);
+
+    useEffect(() => {
+        if (zoom && Math.abs(zoom - currentScale) > 0.01) {
+            handleZoom(zoom);
+        }
+    }, [zoom]);
 
     // Função para verificar se as coordenadas estão dentro da imagem
     const isWithinImageBounds = (x, y) => {
@@ -172,7 +183,8 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
     const handleZoom = (newScale) => {
 
         const stage = stageRef.current;
-        const pointerPosition = stage.getPointerPosition();
+        if (!stage) return;
+        const pointerPosition = stage.getPointerPosition() || { x: stage.width() / 2, y: stage.height() / 2 };
 
         const mouseX = (pointerPosition.x - currentPosition.x) / currentScale;
         const mouseY = (pointerPosition.y - currentPosition.y) / currentScale;
@@ -191,6 +203,17 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
             return updatedPositions
         })
     }
+
+    const handleImageSettingChange = (key, value) => {
+        const nextSettings = {
+            ...(imageSettings || {}),
+            [key]: value,
+        };
+        onImageSettingsChange?.(nextSettings);
+        if (key === 'zoom') {
+            handleZoom(value);
+        }
+    };
 
     // Função para limpar anotações
     const handleClearAnnotations = () => {
@@ -497,7 +520,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
     return (
         <div className='w-[750px] flex flex-col items-center rounded-lg overflow-hidden'>
             {/* Cabeçalho (com os botões) */}
-            <div className='relative bg-red text-white w-full flex items-center px-6 py-3'>
+            <div className='relative bg-green text-white w-full flex items-center px-6 py-3'>
                 <h5 className='mr-4'>Manual Annotation</h5>
 
                 <div className='flex ml-auto'>
@@ -516,7 +539,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                     {isDrawing ? (
                         <button 
                             onClick={toggleDrawingMode} 
-                            className='flex items-center bg-red-dark rounded-lg py-2 px-4 space-x-2 text-white'
+                            className='flex items-center bg-green-dark rounded-lg py-2 px-4 space-x-2 text-white'
                             title='Cancel Manual Annotation'
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><path fill="currentColor" d="M18.66 2c-.26 0-.5.09-.69.28l-1.84 1.85l3.75 3.75l1.84-1.85c.39-.39.39-1.03 0-1.4l-2.34-2.35c-.2-.19-.47-.28-.72-.28M3.28 4L2 5.28l6.5 6.47l-4.5 4.5V20h3.75l4.5-4.5l6.47 6.5L20 20.72l-6.5-6.47l-3.75-3.75zm11.78 1.19l-4.03 4.03l3.75 3.75l4.03-4.03z"></path></svg>
@@ -525,7 +548,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                     ) : predictedValveBoxes[currentFrame] ? (
                         <button 
                             onClick={handleResetValvePosition} 
-                            className='p-2 rounded-sm flex items-center gap-4 transition-colors bg-red-dark disabled:hidden'
+                            className='p-2 rounded-sm flex items-center gap-4 transition-colors bg-green-dark disabled:hidden'
                             title='Reset AI Annotation'
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}><path d="M12 3a9 9 0 1 1-5.657 2"></path><path d="M3 4.5h4v4"></path></g></svg>
@@ -538,7 +561,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                             annotated={rects[currentFrame]?.length > 0}
                         >
                             <button 
-                                className='flex items-center bg-red-dark rounded-lg py-2 px-4 space-x-2 text-white'
+                                className='flex items-center bg-green-dark rounded-lg py-2 px-4 space-x-2 text-white'
                                 title="AI Valve Detection Tool"
                             >
                                 <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><g fill="none" fillRule="evenodd"><path d="m12.593 23.258l-.011.002l-.071.035l-.02.004l-.014-.004l-.071-.035q-.016-.005-.024.005l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.017-.018m.265-.113l-.013.002l-.185.093l-.01.01l-.003.011l.018.43l.005.012l.008.007l.201.093q.019.005.029-.008l.004-.014l-.034-.614q-.005-.018-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.004-.011l.017-.43l-.003-.012l-.01-.01z"></path><path fill="currentColor" d="M20.131 3.16a3 3 0 0 0-4.242 0l-.707.708l4.95 4.95l.706-.707a3 3 0 0 0 0-4.243l-.707-.707Zm-1.414 7.072l-4.95-4.95l-9.09 9.091a1.5 1.5 0 0 0-.401.724l-1.029 4.455a1 1 0 0 0 1.2 1.2l4.456-1.028a1.5 1.5 0 0 0 .723-.401z"></path></g></svg>
@@ -550,7 +573,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                     {/* Botão de deteção do cálcio */}
                     <button 
                         onClick={handleDetectCalcium} 
-                        className='flex items-center bg-red-dark rounded-lg py-2 px-4 space-x-2 text-white'
+                        className='flex items-center bg-green-dark rounded-lg py-2 px-4 space-x-2 text-white'
                         title='AI Calcium Detection Tool'
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><g fill="none"><path d="m12.594 23.258l-.012.002l-.071.035l-.02.004l-.014-.004l-.071-.036q-.016-.004-.024.006l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.016-.018m.264-.113l-.014.002l-.184.093l-.01.01l-.003.011l.018.43l.005.012l.008.008l.201.092q.019.005.029-.008l.004-.014l-.034-.614q-.005-.019-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.003-.011l.018-.43l-.003-.012l-.01-.01z"></path><path fill="currentColor" d="M9.107 5.448c.598-1.75 3.016-1.803 3.725-.159l.06.16l.807 2.36a4 4 0 0 0 2.276 2.411l.217.081l2.36.806c1.75.598 1.803 3.016.16 3.725l-.16.06l-2.36.807a4 4 0 0 0-2.412 2.276l-.081.216l-.806 2.361c-.598 1.75-3.016 1.803-3.724.16l-.062-.16l-.806-2.36a4 4 0 0 0-2.276-2.412l-.216-.081l-2.36-.806c-1.751-.598-1.804-3.016-.16-3.724l.16-.062l2.36-.806A4 4 0 0 0 8.22 8.025l.081-.216zM19 2a1 1 0 0 1 .898.56l.048.117l.35 1.026l1.027.35a1 1 0 0 1 .118 1.845l-.118.048l-1.026.35l-.35 1.027a1 1 0 0 1-1.845.117l-.048-.117l-.35-1.026l-1.027-.35a1 1 0 0 1-.118-1.845l.118-.048l1.026-.35l.35-1.027A1 1 0 0 1 19 2"></path></g></svg>
@@ -559,6 +582,54 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                 </div>
             </div>
             {/* Área de seleção */}
+            <div className="w-full bg-green-soft border-y border-green-pale px-6 py-3 text-sm text-gray-dark">
+                <div className="grid grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                        <span className="font-medium">Luminosidade ({brightness.toFixed(2)})</span>
+                        <input
+                            type="range"
+                            min="0.7"
+                            max="1.6"
+                            step="0.05"
+                            value={brightness}
+                            onChange={(event) => handleImageSettingChange('brightness', Number(event.target.value))}
+                        />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                        <span className="font-medium">Contraste ({contrast.toFixed(2)})</span>
+                        <input
+                            type="range"
+                            min="0.7"
+                            max="1.6"
+                            step="0.05"
+                            value={contrast}
+                            onChange={(event) => handleImageSettingChange('contrast', Number(event.target.value))}
+                        />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                        <span className="font-medium">Redução de ruído ({blur.toFixed(1)}px)</span>
+                        <input
+                            type="range"
+                            min="0"
+                            max="4"
+                            step="0.2"
+                            value={blur}
+                            onChange={(event) => handleImageSettingChange('blur', Number(event.target.value))}
+                        />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                        <span className="font-medium">Zoom ({zoom.toFixed(2)}x)</span>
+                        <input
+                            type="range"
+                            min="0.6"
+                            max="2.4"
+                            step="0.05"
+                            value={zoom}
+                            onChange={(event) => handleImageSettingChange('zoom', Number(event.target.value))}
+                        />
+                    </label>
+                </div>
+            </div>
             <div className={`grid-texture relative w-full h-[560px] overflow-hidden bg-gray-soft`}>
                 <Stage
                     width={Math.max(720, window.innerWidth * 2 / 3)} // 840
@@ -568,7 +639,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                     onMouseMove={handleMouseMove}
                     onMouseUp={handleMouseUp}
                     onClick={() => setSelectedRect(null)}
-                    style={{ cursor: cursorType }}
+                    style={{ cursor: cursorType, filter: `brightness(${brightness}) contrast(${contrast}) blur(${blur}px)` }}
                 >
                     <Layer>
                         <Group 
@@ -746,12 +817,12 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                         </div>
                         
                         <button 
-                            className='relative z-5 w-24 py-1 mt-4 text-center rounded-sm text-lg font-medium bg-red-dark text-white'
+                            className='relative z-5 w-24 py-1 mt-4 text-center rounded-sm text-lg font-medium bg-green-dark text-white'
                             onClick={() => cancelSingleDetection()}
                         >
                             Cancel
                         </button>
-                        <div className='absolute inset-0 bg-blue-400/10 backdrop-blur-xs' />
+                        <div className='absolute inset-0 bg-green-400/10 backdrop-blur-xs' />
                     </div>
                 )}
 
@@ -824,7 +895,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                 )}
             </div>
 
-            <div className='w-full h-28 grid grid-cols-[72%_auto] gap-3 rounded-b-xl bg-red'>
+            <div className='w-full h-28 grid grid-cols-[72%_auto] gap-3 rounded-b-xl bg-green'>
                 {/* Slider com as imagens do paciente */}
                 <AnnotationToolSlider 
                     frames={frames} 
@@ -838,7 +909,7 @@ export default function AnnotationTool({ frames, currentFrame, setCurrentFrame, 
                     {/* Botão de deteção das válvulas em batch */}
                     <button 
                         onClick={handleBatchValvesDetection}
-                        className='p-2 rounded-sm flex items-center justify-center gap-4 transition-colors bg-red-dark disabled:hidden'
+                        className='p-2 rounded-sm flex items-center justify-center gap-4 transition-colors bg-green-dark disabled:hidden'
                         title="Batch Valve Identification Tool"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><path fill="none" stroke="currentColor" strokeWidth={2} d="M19 15h4V1H9v4m6 14h4V5H5v4M1 23h14V9H1z"></path></svg>

--- a/frontend/src/components/AnnotationToolMenu.jsx
+++ b/frontend/src/components/AnnotationToolMenu.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import api, { createReport, getEchoResults } from "../api";
+import api, { createReport, getEchoResults, getExamSettings, updateExamSettings } from "../api";
 import { useUser } from "../contexts/UserContext";
 import AlertDialog from "./AlertDialogMenu";
 import { useUnsavedStore } from "../store/useUnsavedStore";
@@ -8,21 +8,48 @@ import { Switch, Tooltip } from "radix-ui";
 import ReportPDF from "./ReportPDF";
 import { pdf } from "@react-pdf/renderer";
 
-const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCalcification, calcificationStatus, setCalcificationStatus, predictionHistory, patient, echoId }) => {
+const VO_THRESHOLD = 0.66;
+
+const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCalcification, calcificationStatus, setCalcificationStatus, predictionHistory, patient, exam, echoId }) => {
   const [echoName, setEchoName] = useState("");
   const [autoReport, setAutoReport] = useState(true);
+  const [voInfoOpen, setVoInfoOpen] = useState(false);
+  const [classificationChoice, setClassificationChoice] = useState(null);
+  const [classificationConfirmed, setClassificationConfirmed] = useState(false);
+  const [isValidated, setIsValidated] = useState(false);
+  const [reportText, setReportText] = useState("");
   const form = useRef(null);
   const { user } = useUser();
   const navigate = useNavigate();
   const { setUnsavedChanges, hasUnsavedChanges } = useUnsavedStore();
 
+  const voValue = exam?.vo ?? null;
+  const autoClassification = voValue !== null ? voValue >= VO_THRESHOLD : false;
+  const activeClassification = classificationChoice === null ? autoClassification : classificationChoice;
+
   useEffect(() => {
-    if (patient) {
-      setEchoName(
-        patient.echocardiograms.find((echo) => echo.id == echoId).description
-      );
+    if (patient && exam) {
+      setEchoName(exam.description);
     }
-  }, [patient]);
+  }, [patient, exam]);
+
+  useEffect(() => {
+    const hydrateSettings = async () => {
+      if (!echoId) return;
+      const settings = await getExamSettings(echoId);
+      if (settings) {
+        setClassificationChoice(
+          settings.classificationOverride !== undefined
+            ? settings.classificationOverride
+            : null
+        );
+        setClassificationConfirmed(Boolean(settings.classificationConfirmed));
+        setIsValidated(Boolean(settings.validated));
+        setReportText(settings.reportText || "");
+      }
+    };
+    hydrateSettings();
+  }, [echoId]);
 
   useEffect(() => {
     const rectList = rects[currentFrame];
@@ -45,8 +72,6 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
         // Se os resultados do cálcio já estiverem disponíveis, atualiza o status de calcificação
         savedPrediction.results?.binary_classification &&
           setCalcificationStatus(savedPrediction.results.binary_classification);
-
-        console.log("encontrado no histórico");
       } else {
         // Se não houver predição, limpa o valor
         setCalcification((prev) => {
@@ -56,7 +81,6 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
         });
 
         setCalcificationStatus(null);
-        console.log("não encontrado no histórico");
       }
     } else {
       // Se não houver rects, limpa o valor também
@@ -77,21 +101,22 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
         frame_id: frame.id,
         rects: [...rects[frameIndex]],
         is_calcified: calcificationStatus,
-        generated_calcium:
-          calcification[frameIndex]?.is_calcification_generated,
+        generated_calcium: calcification[frameIndex]?.is_calcification_generated,
       }));
 
       await api.post(
         `/api/patient/${patient.id}/echocardiogram/${echoId}/submit/`,
         { results, completed, echoName }
-      );      // Gera o relatório automaticamente
+      );
+      // Gera o relatório automaticamente
       if (autoReport && completed) {
         try {
           const echoData = await getEchoResults(patient.id);
 
-          const pdfBlob = await generatePdfBlob(echoData, patient, user);
+          const pdfBlob = await generatePdfBlob(echoData, patient, user, reportText);
           const formData = new FormData();
           formData.append("pdf_file", pdfBlob, `report_${patient.id}.pdf`);
+          formData.append("reportText", reportText);
 
           await createReport(formData, patient.id);
         } catch (err) {
@@ -106,9 +131,14 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
     }
   };
 
-  const generatePdfBlob = async (echoData, selectedPatient, user) => {
+  const generatePdfBlob = async (echoData, selectedPatient, user, reportText) => {
     const doc = (
-      <ReportPDF data={echoData} patient={selectedPatient} medico={user} />
+      <ReportPDF
+        data={echoData}
+        patient={selectedPatient}
+        medico={user}
+        reportText={reportText}
+      />
     );
     const asPdf = pdf([]);
     asPdf.updateContainer(doc);
@@ -129,9 +159,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
     });
   };
 
-  const framesWithValve = rects.filter(
-    (frameRects) => frameRects.length > 0
-  ).length;
+  const framesWithValve = rects.filter((frameRects) => frameRects.length > 0).length;
   const framesCompleted = rects.filter(
     (frameRects, idx) => frameRects.length > 0 && calcification[idx] !== null
   ).length;
@@ -139,14 +167,58 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
     (frameRects, idx) => frameRects.length > 0 && calcification[idx] !== null
   );
 
+  const riskBadge = () => {
+    if (voValue === null || voValue === undefined) return null;
+    if (voValue < 0.33) {
+      return { label: 'Baixo risco', className: 'bg-green-600 text-white' };
+    }
+    if (voValue < 0.66) {
+      return { label: 'Risco moderado', className: 'bg-orange-500 text-white' };
+    }
+    return { label: 'Alto risco', className: 'bg-red text-white' };
+  };
+
+  const handleConfirmClassification = async () => {
+    await updateExamSettings(echoId, {
+      classificationOverride: classificationChoice,
+      classificationConfirmed: true,
+    });
+    setClassificationConfirmed(true);
+  };
+
+  const handleEditClassification = async () => {
+    await updateExamSettings(echoId, {
+      classificationConfirmed: false,
+    });
+    setClassificationConfirmed(false);
+  };
+
+  const handleValidation = async () => {
+    await updateExamSettings(echoId, { validated: true });
+    setIsValidated(true);
+  };
+
+  const handleGenerateReport = async () => {
+    if (!patient || !exam) return;
+    const template = `RELATÓRIO AUTOMÁTICO - CALCIVISION\n\nPaciente: ${patient.name}\nData do exame: ${new Date(exam.date).toLocaleDateString('pt-PT')}\nVariável Objetiva (VO): ${
+      voValue !== null ? (voValue * 100).toFixed(0) : 'N/A'
+    }%\nClassificação: ${activeClassification ? 'Calcificada' : 'Não calcificada'}\n\nObservações automáticas:\n- Comparação longitudinal recomendada para acompanhar a progressão.\n- Este resultado é uma simulação e não substitui a decisão clínica.\n\nAssinatura: ${user?.first_name || 'Médico'} ${user?.last_name || ''}`;
+    setReportText(template);
+    await updateExamSettings(echoId, { reportText: template });
+  };
+
+  const handleReportChange = async (value) => {
+    setReportText(value);
+    await updateExamSettings(echoId, { reportText: value, reportUpdatedAt: new Date().toISOString() });
+  };
+
   return (
-    <div className="bg-gray-light p-3 rounded-lg w-full border-t-6 border-red-dark mb-4">
+    <div className="bg-gray-light p-3 rounded-lg w-full border-t-6 border-green-dark mb-4">
       <form id="form" ref={form} className="p-2">
         <div>
           <h3 className="mb-2">{patient?.name}</h3>
           <p>
-            Select the area of interest on the image by drawing a box at the
-            location of the valve.
+            Select the area of interest on the image by drawing a box at the location of the valve.
           </p>
         </div>
 
@@ -168,21 +240,15 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
           <ul className="space-y-1">
             <li>
               <span className="text-gray-600">Total frames:</span>
-              <span className="ml-2 font-medium text-gray-900">
-                {frames.length}
-              </span>
+              <span className="ml-2 font-medium text-gray-900">{frames.length}</span>
             </li>
             <li>
               <span className="text-gray-600">Valve identified:</span>
-              <span className="ml-2 font-medium text-gray-900">
-                {framesWithValve}
-              </span>
+              <span className="ml-2 font-medium text-gray-900">{framesWithValve}</span>
             </li>
             <li>
               <span className="text-gray-600">Completed annotations:</span>
-              <span className="ml-2 font-medium text-gray-900">
-                {framesCompleted}
-              </span>
+              <span className="ml-2 font-medium text-gray-900">{framesCompleted}</span>
             </li>
           </ul>
 
@@ -206,7 +272,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
               role="alert"
             >
               <div className="p-1 rounded-full bg-orange-100 text-orange-600">
-                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 1024 1024"fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 1024 1024" fill="currentColor">
                   <path d="M512 64a448 448 0 1 1 0 896a448 448 0 0 1 0-896m0 192a58.43 58.43 0 0 0-58.24 63.744l23.36 256.384a35.072 35.072 0 0 0 69.76 0l23.296-256.384A58.43 58.43 0 0 0 512 256m0 512a51.2 51.2 0 1 0 0-102.4a51.2 51.2 0 0 0 0 102.4" />
                 </svg>
               </div>
@@ -215,14 +281,116 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
           )}
         </div>
 
+        <div className="mt-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h4>Variável Objetiva (VO)</h4>
+            <button
+              type="button"
+              className="text-green-dark text-sm font-medium"
+              onClick={() => setVoInfoOpen(!voInfoOpen)}
+            >
+              O que é a VO?
+            </button>
+          </div>
+          {voInfoOpen && (
+            <div className="rounded-md bg-green-50 p-3 text-sm text-green-900 ring-1 ring-green-100">
+              A VO representa o grau estimado de calcificação e permite comparar exames ao longo do tempo.
+              Este valor é simulado e não substitui a decisão clínica.
+            </div>
+          )}
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-3xl font-semibold text-gray-900">
+              {voValue !== null ? `${(voValue * 100).toFixed(0)}%` : 'N/A'}
+            </span>
+            {riskBadge() && (
+              <span className={`px-3 py-1 rounded-full text-xs font-semibold ${riskBadge().className}`}>
+                {riskBadge().label}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          <h4>Classificação da válvula</h4>
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              className={`h-12 rounded flex justify-center items-center border ${
+                activeClassification
+                  ? 'bg-green text-white border-green-dark'
+                  : 'bg-gray-200 border-gray-medium-dark'
+              }`}
+              onClick={() => setClassificationChoice(true)}
+            >
+              Calcificada
+            </button>
+            <button
+              type="button"
+              className={`h-12 rounded flex justify-center items-center border ${
+                !activeClassification
+                  ? 'bg-green text-white border-green-dark'
+                  : 'bg-gray-200 border-gray-medium-dark'
+              }`}
+              onClick={() => setClassificationChoice(false)}
+            >
+              Não calcificada
+            </button>
+          </div>
+          <div className="flex items-center gap-3">
+            {!classificationConfirmed ? (
+              <button
+                type="button"
+                className="bg-green-dark text-white px-4 py-2 rounded"
+                onClick={handleConfirmClassification}
+              >
+                Confirmar classificação
+              </button>
+            ) : (
+              <>
+                <span className="text-sm font-semibold text-green-dark">Classificação confirmada</span>
+                <button
+                  type="button"
+                  className="text-sm text-green-dark underline"
+                  onClick={handleEditClassification}
+                >
+                  Alterar classificação
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          <h4>Validação da deteção</h4>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className={`px-4 py-2 rounded ${
+                isValidated
+                  ? 'bg-green-100 text-green-900'
+                  : 'bg-green-dark text-white'
+              }`}
+              onClick={handleValidation}
+              disabled={isValidated}
+            >
+              {isValidated ? 'Deteção validada' : 'Validar deteção'}
+            </button>
+            <span className="text-sm text-gray-600">
+              {isValidated
+                ? 'Próximo passo desbloqueado.'
+                : 'Valide para gerar relatório.'}
+            </span>
+          </div>
+        </div>
+
         <h4 className="mt-4">Calcification</h4>
         <div className="grid grid-cols-2 justify-center gap-3 mt-4">
           <button
             type="button"
             className={`relative h-12 rounded flex justify-center items-center ${
               calcificationStatus === true
-                ? "bg-red text-white border border-gray-medium-dark"
-                : "bg-gray-200 border border-gray-medium-dark"
+                ? 'bg-green text-white border border-gray-medium-dark'
+                : 'bg-gray-200 border border-gray-medium-dark'
             }`}
             onClick={() => updateCalcification(true)}
           >
@@ -230,7 +398,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
               (calcification[currentFrame]?.is_calcification_generated ? (
                 <div className="absolute top-2 left-2">
                   <svg xmlns="http://www.w3.org/2000/svg" width={18} height={18} viewBox="0 0 24 24">
-                    <g fill="currentColor"><path d="m12.594 23.258l-.012.002l-.071.035l-.02.004l-.014-.004l-.071-.036q-.016-.004-.024.006l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.016-.018m.264-.113l-.014.002l-.184.093l-.01.01l-.003.011l.018.43l.005.012l.008.008l.201.092q.019.005.029-.008l.004-.014l-.034-.614q-.005-.019-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.003-.011l.018-.43l-.003-.012l-.01-.01z"></path><path className={`${calcificationStatus === true ? "bg-gray-pale" : "bg-gray-medium-dark"}`} d="M9.107 5.448c.598-1.75 3.016-1.803 3.725-.159l.06.16l.807 2.36a4 4 0 0 0 2.276 2.411l.217.081l2.36.806c1.75.598 1.803 3.016.16 3.725l-.16.06l-2.36.807a4 4 0 0 0-2.412 2.276l-.081.216l-.806 2.361c-.598 1.75-3.016 1.803-3.724.16l-.062-.16l-.806-2.36a4 4 0 0 0-2.276-2.412l-.216-.081l-2.36-.806c-1.751-.598-1.804-3.016-.16-3.724l.16-.062l2.36-.806A4 4 0 0 0 8.22 8.025l.081-.216zM19 2a1 1 0 0 1 .898.56l.048.117l.35 1.026l1.027.35a1 1 0 0 1 .118 1.845l-.118.048l-1.026.35l-.35 1.027a1 1 0 0 1-1.845.117l-.048-.117l-.35-1.026l-1.027-.35a1 1 0 0 1-.118-1.845l.118-.048l1.026-.35l.35-1.027A1 1 0 0 1 19 2"></path></g>
+                    <g fill="currentColor"><path d="m12.594 23.258l-.012.002l-.071.035l-.02.004l-.014-.004l-.071-.036q-.016-.004-.024.006l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.016-.018m.264-.113l-.014.002l-.184.093l-.01.01l-.003.011l.018.43l.005.012l.008.008l.201.092q.019.005.029-.008l.004-.014l-.034-.614q-.005-.019-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.003-.011l.018-.43l-.003-.012l-.01-.01z"></path><path className={`${calcificationStatus === true ? "bg-gray-pale" : "bg-gray-medium-dark"}`} d="M9.107 5.448c.598-1.75 3.016-1.803 3.725-.159l.06.16l.807 2.36a4 4 0 0 0 2.276 2.411l.217.081l2.36.806c1.75.598 1.803 3.016.16 3.725l-.16.06l-2.36.807a4 4 0 0 0-2.412 2.276l-.081.216l-.806 2.361c-.598 1.75-3.016 1.803-3.724.16l-.062-.16l-.806-2.36a4 4 0 0 0-2.276-2.412l-.216-.081l-2.36-.806c-1.751-.598-1.804-3.016-.16-3.724l.16-.062l2.36-.806A4 4 0 0 0 8.22 8.025l.081-.216zM19 2a1 1 0 0 1 .898.56l.048.117l.35 1.026l1.027.35a1 1 0 0 1 .118 1.845l-.118.048l-1.026.35l-.35 1.027A1 1 0 0 1 19 2"></path></g>
                   </svg>
                 </div>
               ) : (
@@ -247,8 +415,8 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
             type="button"
             className={`relative h-12 rounded flex justify-center items-center ${
               calcificationStatus === false
-                ? "bg-red text-white border border-gray-medium-dark"
-                : "bg-gray-200 border border-gray-medium-dark"
+                ? 'bg-green text-white border border-gray-medium-dark'
+                : 'bg-gray-200 border border-gray-medium-dark'
             }`}
             onClick={() => updateCalcification(false)}
           >
@@ -256,7 +424,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
               (calcification[currentFrame]?.is_calcification_generated ? (
                 <div className="absolute top-2 left-2">
                   <svg xmlns="http://www.w3.org/2000/svg" width={18} height={18} viewBox="0 0 24 24">
-                    <g fill="currentColor"><path d="m12.594 23.258l-.012.002l-.071.035l-.02.004l-.014-.004l-.071-.036q-.016-.004-.024.006l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.016-.018m.264-.113l-.014.002l-.184.093l-.01.01l-.003.011l.018.43l.005.012l.008.008l.201.092q.019.005.029-.008l.004-.014l-.034-.614q-.005-.019-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.003-.011l.018-.43l-.003-.012l-.01-.01z"></path><path className={`${calcificationStatus === true ? "bg-gray-pale" : "bg-gray-medium-dark"}`} d="M9.107 5.448c.598-1.75 3.016-1.803 3.725-.159l.06.16l.807 2.36a4 4 0 0 0 2.276 2.411l.217.081l2.36.806c1.75.598 1.803 3.016.16 3.725l-.16.06l-2.36.807a4 4 0 0 0-2.412 2.276l-.081.216l-.806 2.361c-.598 1.75-3.016 1.803-3.724.16l-.062-.16l-.806-2.36a4 4 0 0 0-2.276-2.412l-.216-.081l-2.36-.806c-1.751-.598-1.804-3.016-.16-3.724l.16-.062l2.36-.806A4 4 0 0 0 8.22 8.025l.081-.216zM19 2a1 1 0 0 1 .898.56l.048.117l.35 1.026l1.027.35a1 1 0 0 1 .118 1.845l-.118.048l-1.026.35l-.35 1.027a1 1 0 0 1-1.845.117l-.048-.117l-.35-1.026l-1.027-.35a1 1 0 0 1-.118-1.845l.118-.048l1.026-.35l.35-1.027A1 1 0 0 1 19 2"></path></g>
+                    <g fill="currentColor"><path d="m12.594 23.258l-.012.002l-.071.035l-.02.004l-.014-.004l-.071-.036q-.016-.004-.024.006l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.016-.018m.264-.113l-.014.002l-.184.093l-.01.01l-.003.011l.018.43l.005.012l.008.008l.201.092q.019.005.029-.008l.004-.014l-.034-.614q-.005-.019-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.003-.011l.018-.43l-.003-.012l-.01-.01z"></path><path className={`${calcificationStatus === true ? "bg-gray-pale" : "bg-gray-medium-dark"}`} d="M9.107 5.448c.598-1.75 3.016-1.803 3.725-.159l.06.16l.807 2.36a4 4 0 0 0 2.276 2.411l.217.081l2.36.806c1.75.598 1.803 3.016.16 3.725l-.16.06l-2.36.807a4 4 0 0 0-2.412 2.276l-.081.216l-.806 2.361c-.598 1.75-3.016 1.803-3.724.16l-.062-.16l-.806-2.36a4 4 0 0 0-2.276-2.412l-.216-.081l-2.36-.806c-1.751-.598-1.804-3.016-.16-3.724l.16-.062l2.36-.806A4 4 0 0 0 8.22 8.025l.081-.216zM19 2a1 1 0 0 1 .898.56l.048.117l.35 1.026l1.027.35a1 1 0 0 1 .118 1.845l-.118.048l-1.026.35l-.35 1.027A1 1 0 0 1 19 2"></path></g>
                   </svg>
                 </div>
               ) : (
@@ -275,25 +443,14 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
             calcification[currentFrame]?.binary_classification !== null && // ou null
             (calcification[currentFrame]?.is_calcification_generated ? (
               calcification[currentFrame].binary_classification ? (
-                <strong>
-                  The algorithm detected calcium deposits in the delimited area.
-                </strong>
+                <strong>The algorithm detected calcium deposits in the delimited area.</strong>
               ) : (
-                <strong>
-                  The algorithm did not detect calcium deposits in the delimited
-                  area.
-                </strong>
+                <strong>The algorithm did not detect calcium deposits in the delimited area.</strong>
               )
             ) : calcification[currentFrame]?.binary_classification ? (
-              <strong>
-                Dr. {user?.first_name + " " + user?.last_name} marked the valve
-                area as calcified.
-              </strong>
+              <strong>Dr. {user?.first_name + " " + user?.last_name} marked the valve area as calcified.</strong>
             ) : (
-              <strong>
-                Dr. {user?.first_name + " " + user?.last_name} marked the valve
-                area as not calcified.
-              </strong>
+              <strong>Dr. {user?.first_name + " " + user?.last_name} marked the valve area as not calcified.</strong>
             ))}
         </div>
       </form>
@@ -306,11 +463,11 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
         <Switch.Root
           checked={autoReport}
           onCheckedChange={() => setAutoReport(!autoReport)}
-          className="relative h-5 w-9 cursor-default rounded-full bg-red-dark outline-none data-[state=checked]:bg-green-800"
+          className="relative h-5 w-9 cursor-default rounded-full bg-green-dark outline-none data-[state=checked]:bg-green-800"
           id="auto-report"
           style={{ "-webkit-tap-highlight-color": "rgba(0, 0, 0, 0)" }}
         >
-          <Switch.Thumb className="block size-4 translate-x-0.5 rounded-full bg-white shadow-[0_1px_1px] shadow-red-950 transition-transform duration-150 ease-out will-change-transform data-[state=checked]:translate-x-[18px]" />
+          <Switch.Thumb className="block size-4 translate-x-0.5 rounded-full bg-white shadow-[0_1px_1px] shadow-green-950 transition-transform duration-150 ease-out will-change-transform data-[state=checked]:translate-x-[18px]" />
         </Switch.Root>
 
         <Tooltip.Provider delayDuration={500}>
@@ -327,15 +484,52 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
                 className="select-none max-w-82 rounded bg-white px-[15px] py-2.5 text-sm leading-none text-gray-medium-dark shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity] data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade"
                 sideOffset={5}
               >
-                Indicates whether or not the clinical report will be
-                automatically generated when results are submitted. If so, the
-                report will be available in Records and in the respective
-                patient's menu.
+                Indicates whether or not the clinical report will be automatically generated when results are submitted.
+                If so, the report will be available in Records and in the respective patient's menu.
                 <Tooltip.Arrow className="fill-white" />
               </Tooltip.Content>
             </Tooltip.Portal>
           </Tooltip.Root>
         </Tooltip.Provider>
+      </div>
+
+      <div className="mt-6 space-y-3">
+        <div className="flex items-center justify-between">
+          <h4>Relatório clínico</h4>
+          <button
+            type="button"
+            className="text-green-dark text-sm font-medium"
+            onClick={handleGenerateReport}
+            disabled={!isValidated}
+          >
+            Gerar relatório
+          </button>
+        </div>
+        <p className="text-sm text-gray-600">
+          {isValidated
+            ? 'Gerar automaticamente e ajustar observações antes de exportar.'
+            : 'Valide a deteção para desbloquear o relatório.'}
+        </p>
+        <textarea
+          className="w-full min-h-[180px] rounded border border-gray-pale p-3 text-sm bg-white"
+          value={reportText}
+          onChange={(event) => handleReportChange(event.target.value)}
+          placeholder="Clique em 'Gerar relatório' para preencher o template."
+          disabled={!isValidated}
+        />
+        <button
+          type="button"
+          className="bg-green-dark text-white px-4 py-2 rounded"
+          onClick={async () => {
+            const echoData = await getEchoResults(patient.id);
+            const pdfBlob = await generatePdfBlob(echoData, patient, user, reportText);
+            const url = URL.createObjectURL(pdfBlob);
+            window.open(url, '_blank');
+          }}
+          disabled={!reportText}
+        >
+          Exportar PDF
+        </button>
       </div>
 
       <div className="w-full flex gap-2 mt-8">
@@ -348,7 +542,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
             navigate(`/select_echo?patient=${patient.id}&echo=${echoId}`);
           }}
         >
-          <button className="grid place-items-center basis-24 border-red border-2 rounded-lg py-2 text-gray-dark">
+          <button className="grid place-items-center basis-24 border-green-dark border-2 rounded-lg py-2 text-gray-dark">
             Cancel
           </button>
         </AlertDialog>
@@ -359,7 +553,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
           text="This action cannot be undone! The current annotation data will be overwritten with the new changes."
           onConfirm={() => handleUpdateEcho(false)}
         >
-          <button className="grid place-items-center basis-24 bg-red rounded-lg py-2 text-white">
+          <button className="grid place-items-center basis-24 bg-green rounded-lg py-2 text-white">
             Save
           </button>
         </AlertDialog>
@@ -370,7 +564,7 @@ const AnnotationToolMenu = ({ frames, currentFrame, rects, calcification, setCal
           text={`This action will formalize ${patient?.name}'s analysis results and mark the echocardiography as complete.`}
           onConfirm={() => handleUpdateEcho(true)}
         >
-          <button className="basis-50 flex items-center justify-center gap-2 ml-auto bg-red-dark rounded-lg py-2 px-6 text-white">
+          <button className="basis-50 flex items-center justify-center gap-2 ml-auto bg-green-dark rounded-lg py-2 px-6 text-white">
             <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} viewBox="0 0 16 16">
               <path fill="currentColor" fillRule="evenodd" d="M2 2.5a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 .5.5V7h-1V3H3v10h2.005v1H2.5a.5.5 0 0 1-.5-.5zm11.994 6.832l-4.52 4.519a.5.5 0 0 1-.706 0l-2.51-2.51l.706-.708l2.157 2.157l4.166-4.166z" clipRule="evenodd"></path>
             </svg>

--- a/frontend/src/components/AnnotationToolSlider.jsx
+++ b/frontend/src/components/AnnotationToolSlider.jsx
@@ -67,7 +67,7 @@ function AnnotationToolSlider({ frames, rects, currentFrame, setCurrentFrame, ba
                             {isLoading && (
                                 <div className='absolute inset-0 flex flex-col justify-center items-center'>
                                     <span role='status' className='relative z-5 w-8 h-8 rounded-full border-3 border-gray-pale border-t-blue-800 animate-spin' />
-                                    <div className='absolute inset-0 bg-blue-400/10 backdrop-blur-xs rounded-md' />
+                                    <div className='absolute inset-0 bg-green-400/10 backdrop-blur-xs rounded-md' />
                                 </div>
                             )}
                         </div>

--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -82,7 +82,7 @@ function Calendar() {
                     {weekdays.map((day, index) =>
                         <li
                             key={index}
-                            className="text-center text-red-dark font-semibold"
+                            className="text-center text-green-dark font-semibold"
                         >
                             {day}
                         </li>
@@ -119,7 +119,7 @@ function Day({ number, today, currentMonth }) {
     return (
         <li className={`grid place-items-center relative ${currentMonth ? 'text-gray-dark' : 'text-gray-medium'} ${today ? 'text-white' : 'text-current'}`}>
             <span className="z-10">{number}</span>
-            {today && <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 aspect-square rounded-full bg-red -z-1" />}
+            {today && <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 aspect-square rounded-full bg-green -z-1" />}
         </li>
     )
 }

--- a/frontend/src/components/Form.jsx
+++ b/frontend/src/components/Form.jsx
@@ -36,9 +36,9 @@ function Form({ route, method }) {
     };
 
     return (
-        <form onSubmit={handleSubmit} className="flex flex-col m-15 mx-100 p-5 w-100 bg-red-light">
+        <form onSubmit={handleSubmit} className="flex flex-col m-15 mx-100 p-5 w-100 bg-green-light">
             <input
-                className="bg-red-pale p-2 my-3 h-10 rounded-md border border-black w-full focus:outline-none"
+                className="bg-green-pale p-2 my-3 h-10 rounded-md border border-black w-full focus:outline-none"
                 type="text"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
@@ -46,7 +46,7 @@ function Form({ route, method }) {
             />
 
             <input
-                className="bg-red-pale p-2 my-3 h-10 rounded-md border border-black text-red-dark w-full focus:outline-none"
+                className="bg-green-pale p-2 my-3 h-10 rounded-md border border-black text-green-dark w-full focus:outline-none"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -56,7 +56,7 @@ function Form({ route, method }) {
             {method === "register" && ( // Se register for verdadeiro, então exibe os campos abaixo
                 <>
                     <input
-                        className="bg-red-pale p-2 my-3 h-10 rounded-md border border-black text-red-dark w-full focus:outline-none"
+                        className="bg-green-pale p-2 my-3 h-10 rounded-md border border-black text-green-dark w-full focus:outline-none"
                         type="text"
                         value={medical_speciality}
                         onChange={(e) => setMedical_speciality(e.target.value)}
@@ -64,7 +64,7 @@ function Form({ route, method }) {
                     />
 
                     <input
-                        className="bg-red-pale p-2 my-3 h-10 rounded-md border border-black text-red-dark w-full focus:outline-none"
+                        className="bg-green-pale p-2 my-3 h-10 rounded-md border border-black text-green-dark w-full focus:outline-none"
                         type="text"
                         value={doctor_number}
                         onChange={(e) => setDoctor_number(e.target.value)}
@@ -75,7 +75,7 @@ function Form({ route, method }) {
 
             <div className="flex justify-center">
                 <br />
-                <button className="mt-7 items-center bg-red h-10 w-50 uppercase text-white rounded-md" type="submit">
+                <button className="mt-7 items-center bg-green h-10 w-50 uppercase text-white rounded-md" type="submit">
                     {name}
                 </button>
             </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -12,7 +12,7 @@ export default function Header() {
 
   return (
     <header className="relative left-0 top-0 text-gray-dark">
-      <div className='w-dvw h-[var(--header-height)] flex items-center bg-red-soft border-b-gray-medium border-b-[1px] px-5'>
+      <div className='w-dvw h-[var(--header-height)] flex items-center bg-green-soft border-b-gray-medium border-b-[1px] px-5'>
         <Link to="/">
           <div className="flex items-center gap-4">
             <img src="/calcivision_logo.png" alt="CalciVision" role="img" width={48}/>
@@ -27,7 +27,7 @@ export default function Header() {
             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}><path d="M14 8V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h7a2 2 0 0 0 2-2v-2"></path><path d="M9 12h12l-3-3m0 6l3-3"></path></g></svg>
           </button>
           <div className='grid items-center grid-cols-[auto_1fr] grid-rows-2 gap-x-3 max-w-xs'>
-            <div className='row-start-1 row-span-2 aspect-square h-full border-2 border-red rounded-full object-cover object-center overflow-clip'>
+            <div className='row-start-1 row-span-2 aspect-square h-full border-2 border-green rounded-full object-cover object-center overflow-clip'>
               <img 
                 src={avatar} 
                 alt="user" 
@@ -62,7 +62,7 @@ function SearchButton() {
     const [focused, setFocused] = useState(false);
   
     return (
-      <div className={`w-68 mr-4 flex items-center rounded-full outline-1 bg-white transition-all duration-200 ${focused ? 'outline-red outline-2': 'outline-gray-medium-dark'}`}>
+      <div className={`w-68 mr-4 flex items-center rounded-full outline-1 bg-white transition-all duration-200 ${focused ? 'outline-green outline-2': 'outline-gray-medium-dark'}`}>
         <button className='aspect-square h-full grid place-items-center bg-transparent cursor-pointer'>
           <img src={magnifyingGlassIcon} alt="Search" role="icon" />
         </button>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,7 +4,7 @@ import { useUnsavedStore } from "../store/useUnsavedStore";
 
 export default function Navbar() {
   return (
-    <nav className="no-scrollbar w-80 h-[var(--content-height)] p-5 bg-red-light border-r-gray-medium border-r-[1px] overflow-auto">
+    <nav className="no-scrollbar w-80 h-[var(--content-height)] p-5 bg-green-light border-r-gray-medium border-r-[1px] overflow-auto">
       <ul className="flex flex-col" role='navigation'>
         <ul className="flex flex-col gap-2">
           <NavItem name="Home" url="/">
@@ -72,12 +72,12 @@ function NavItem({ name, url, highlight = false, children }) {
   }, [location, url]);
 
   return (
-    <li className={`nav-link group font-medium p-2 rounded-lg cursor-pointer ${highlight ? 'hover:bg-[#e36d6d]' : 'hover:bg-red-pale'} transition-colors duration-250 *:transition-colors *:duration-250 ${highlight ? 'bg-red text-white' : active ? 'bg-red-pale' : 'bg-transparent'}`}>
+    <li className={`nav-link group font-medium p-2 rounded-lg cursor-pointer ${highlight ? 'hover:bg-green-dark' : 'hover:bg-green-pale'} transition-colors duration-250 *:transition-colors *:duration-250 ${highlight ? 'bg-green text-white' : active ? 'bg-green-pale' : 'bg-transparent'}`}>
       <button onClick={handleClick} className='flex items-center w-full h-full' role='link'>
-        <div className={`grid place-items-center ml-1 mr-3 ${!highlight ? 'group-hover:fill-red group-hover:text-red' : ''} ${active ? 'fill-red-dark text-red-dark' : 'fill-current text-current'}`}>
+        <div className={`grid place-items-center ml-1 mr-3 ${!highlight ? 'group-hover:fill-green group-hover:text-green' : ''} ${active ? 'fill-green-dark text-green-dark' : 'fill-current text-current'}`}>
           {children}
         </div>
-        <span className={`text-lg ${!highlight ? 'group-hover:text-red' : 'text-white'} ${active ? 'text-red-dark' : 'text-gray-dark'}`}>
+        <span className={`text-lg ${!highlight ? 'group-hover:text-green' : 'text-white'} ${active ? 'text-green-dark' : 'text-gray-dark'}`}>
           {name}
         </span>
       </button>

--- a/frontend/src/components/PatientList.jsx
+++ b/frontend/src/components/PatientList.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import UploadDicomFiles from '@components/UploadDicomFiles';
 import api, { deletePatient, deleteReport } from '../api';
 import AlertDialogMenu from './AlertDialogMenu';
@@ -143,7 +144,7 @@ function PatientRow({ patient, defaultState, reloadTable }) {
                     </AlertDialogMenu>
                 </td>
             </tr>
-            <tr className='bg-red-light'>
+            <tr className='bg-green-light'>
                 <td colSpan={7} className='p-0! text-left min-w-8'>
                     <div className={`patient-row-menu transition-[height] ease-out duration-500 overflow-hidden ${isOpen ? 'h-auto' : 'h-0'}`}>
                         <div className="grid xl:grid-cols-[60%_40%] xl:grid-rows-1 grid-rows-2 gap-12 px-15! py-4! border-b-2 border-b-gray-medium">
@@ -189,6 +190,21 @@ function PatientRow({ patient, defaultState, reloadTable }) {
 
 function EchocardiogramsTable({ patient, reloadTable }) {
 
+    const navigate = useNavigate();
+    const [selectedExams, setSelectedExams] = useState([]);
+
+    const handleToggleExam = (examId) => {
+        setSelectedExams((prev) => {
+            if (prev.includes(examId)) {
+                return prev.filter((id) => id !== examId);
+            }
+            if (prev.length >= 2) {
+                return prev;
+            }
+            return [...prev, examId];
+        });
+    };
+
     const handleDeleteEchocardiogram = async (echo) => {
         try {
             await api.delete(`/api/patient/${patient.id}/echocardiogram/${echo.id}/delete/`)
@@ -199,51 +215,108 @@ function EchocardiogramsTable({ patient, reloadTable }) {
     }
     
     return (
-        <table className='table-fixed w-full border-collapse'>
-            <thead>
-                <tr className=''>
-                    <th className="w-2/7 px-4 py-1 text-left truncate border-b-2">Name</th>
-                    <th className="w-1/5 px-4 py-1 text-left truncate border-b-2">Status</th>
-                    <th className="w-1/4 px-4 py-1 text-left truncate border-b-2">Uploaded</th>
-                    <th className="w-1/8 pl-8 py-1"></th>
-                </tr>
-            </thead>
-            <tbody>
-                {patient.echocardiograms?.map((echo, index) =>
-                    <tr key={index}>
-                        <td className="px-4 py-1"><strong>{echo.description}</strong></td>
-                        <td className="px-4 py-1">
-                            <div className={`w-28 py-[3px] text-sm bg-white text-center rounded-md ${echo.status === 'EVALUATED' ? 'text-green-600' : echo.status === 'IN_PROGRESS' ? 'text-amber-600' : 'text-red'}`}>
-                                {formatStatus(echo.status)}
-                            </div>
-                        </td>
-                        <td className="px-4 py-1"><em>{new Date(echo.uploaded_at).toLocaleString('pt-PT', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}</em></td>
-                        <td>
-                            <div className='flex justify-end gap-2'>
-                                <button 
-                                    className='block bg-blue-500 rounded-lg p-[6px] text-white text-sm'
-                                    onClick={() => window.open(`/analyse_aortic_valve/${patient.id}/${echo.id}`, '_blank')}
+        <div>
+            <div className='flex items-center justify-between mb-3 text-sm text-gray-medium-dark'>
+                <span>Selecione dois exames para comparar.</span>
+                <button
+                    className='bg-green-dark text-white px-3 py-1 rounded disabled:opacity-50'
+                    onClick={() => navigate(`/patients/${patient.id}/compare/${selectedExams[0]}/${selectedExams[1]}`)}
+                    disabled={selectedExams.length !== 2}
+                >
+                    Comparar exames
+                </button>
+            </div>
+            <table className='table-fixed w-full border-collapse'>
+                <thead>
+                    <tr className=''>
+                        <th className="w-1/3 px-4 py-1 text-left truncate border-b-2">Exame</th>
+                        <th className="w-1/6 px-4 py-1 text-left truncate border-b-2">Data</th>
+                        <th className="w-1/8 px-4 py-1 text-left truncate border-b-2">
+                            <span className="inline-flex items-center gap-2">
+                                VO
+                                <span
+                                    className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs font-semibold"
+                                    title="A VO representa o grau estimado de calcificação e serve para comparar exames ao longo do tempo."
                                 >
-                                    <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24"><path fill="currentColor" d="m18.988 2.012l3 3L19.701 7.3l-3-3zM8 16h3l7.287-7.287l-3-3L8 13z"/><path fill="currentColor" d="M19 19H8.158c-.026 0-.053.01-.079.01c-.033 0-.066-.009-.1-.01H5V5h6.847l2-2H5c-1.103 0-2 .896-2 2v14c0 1.104.897 2 2 2h14a2 2 0 0 0 2-2v-8.668l-2 2z"/></svg>
-                                </button>
-                                <AlertDialogMenu
-                                    heading='Delete Echocardiogram'
-                                    content={`Are you sure you want to delete echocariogram "${echo.description}"? This action cannot be undone.`}
-                                    onConfirm={() => handleDeleteEchocardiogram(echo)}
-                                >
-                                    <button className='block bg-red rounded-lg p-[6px] text-white text-sm'>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24"><path fill="currentColor" fillRule="evenodd" d="M8.106 2.553A1 1 0 0 1 9 2h6a1 1 0 0 1 .894.553L17.618 6H20a1 1 0 1 1 0 2h-1v11a3 3 0 0 1-3 3H8a3 3 0 0 1-3-3V8H4a1 1 0 0 1 0-2h2.382zM14.382 4l1 2H8.618l1-2zM11 11a1 1 0 1 0-2 0v6a1 1 0 1 0 2 0zm4 0a1 1 0 1 0-2 0v6a1 1 0 1 0 2 0z" clipRule="evenodd"></path></svg>
-                                    </button>
-                                </AlertDialogMenu>
-                            </div>
-                        </td>
+                                    ?
+                                </span>
+                            </span>
+                        </th>
+                        <th className="w-1/6 px-4 py-1 text-left truncate border-b-2">
+                            Risco
+                        </th>
+                        <th className="w-1/6 px-4 py-1 text-left truncate border-b-2">Status</th>
+                        <th className="w-1/8 px-4 py-1 text-center truncate border-b-2">Comparar</th>
+                        <th className="w-1/8 pl-8 py-1"></th>
                     </tr>
-                )}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {patient.echocardiograms?.map((echo, index) => {
+                        const risk = getRiskBadge(echo.vo);
+                        return (
+                            <tr key={index}>
+                                <td className="px-4 py-1"><strong>{echo.description}</strong></td>
+                                <td className="px-4 py-1"><em>{new Date(echo.date || echo.uploaded_at).toLocaleString('pt-PT', { day: '2-digit', month: '2-digit', year: 'numeric' })}</em></td>
+                                <td className="px-4 py-1">{echo.vo !== undefined ? `${Math.round(echo.vo * 100)}%` : '—'}</td>
+                                <td className="px-4 py-1">
+                                    {risk && (
+                                        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${risk.className}`}>
+                                            {risk.label}
+                                        </span>
+                                    )}
+                                </td>
+                                <td className="px-4 py-1">
+                                    <div className={`w-28 py-[3px] text-sm bg-white text-center rounded-md ${echo.status === 'EVALUATED' ? 'text-green-600' : echo.status === 'IN_PROGRESS' ? 'text-amber-600' : 'text-red'}`}>
+                                        {formatStatus(echo.status)}
+                                    </div>
+                                </td>
+                                <td className="px-4 py-1 text-center">
+                                    <input
+                                        type="checkbox"
+                                        checked={selectedExams.includes(echo.id)}
+                                        onChange={() => handleToggleExam(echo.id)}
+                                        disabled={!selectedExams.includes(echo.id) && selectedExams.length >= 2}
+                                    />
+                                </td>
+                                <td>
+                                    <div className='flex justify-end gap-2'>
+                                        <button 
+                                            className='block bg-green rounded-lg p-[6px] text-white text-sm'
+                                            onClick={() => window.open(`/analyse_aortic_valve/${patient.id}/${echo.id}`, '_blank')}
+                                        >
+                                            <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24"><path fill="currentColor" d="m18.988 2.012l3 3L19.701 7.3l-3-3zM8 16h3l7.287-7.287l-3-3L8 13z"/><path fill="currentColor" d="M19 19H8.158c-.026 0-.053.01-.079.01c-.033 0-.066-.009-.1-.01H5V5h6.847l2-2H5c-1.103 0-2 .896-2 2v14c0 1.104.897 2 2 2h14a2 2 0 0 0 2-2v-8.668l-2 2z"/></svg>
+                                        </button>
+                                        <AlertDialogMenu
+                                            heading='Delete Echocardiogram'
+                                            content={`Are you sure you want to delete echocariogram "${echo.description}"? This action cannot be undone.`}
+                                            onConfirm={() => handleDeleteEchocardiogram(echo)}
+                                        >
+                                            <button className='block bg-red rounded-lg p-[6px] text-white text-sm'>
+                                                <svg xmlns="http://www.w3.org/2000/svg" width={16} height={16} viewBox="0 0 24 24"><path fill="currentColor" fillRule="evenodd" d="M8.106 2.553A1 1 0 0 1 9 2h6a1 1 0 0 1 .894.553L17.618 6H20a1 1 0 1 1 0 2h-1v11a3 3 0 0 1-3 3H8a3 3 0 0 1-3-3V8H4a1 1 0 0 1 0-2h2.382zM14.382 4l1 2H8.618l1-2zM11 11a1 1 0 1 0-2 0v6a1 1 0 1 0 2 0zm4 0a1 1 0 1 0-2 0v6a1 1 0 1 0 2 0z" clipRule="evenodd"></path></svg>
+                                            </button>
+                                        </AlertDialogMenu>
+                                    </div>
+                                </td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
     )
 }
 
 const formatStatus = (text) => {
     return text.replace('_', ' ').toLowerCase().split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 }
+
+const getRiskBadge = (vo) => {
+    if (vo === undefined || vo === null) return null;
+    if (vo < 0.33) {
+        return { label: 'Baixo', className: 'bg-green-600 text-white' };
+    }
+    if (vo < 0.66) {
+        return { label: 'Médio', className: 'bg-orange-500 text-white' };
+    }
+    return { label: 'Alto', className: 'bg-red text-white' };
+};

--- a/frontend/src/components/PatientRegister.jsx
+++ b/frontend/src/components/PatientRegister.jsx
@@ -84,7 +84,7 @@ const PatientRegister = ({ onClose }) => {
       >
         <h2 className="text-center font-bold mb-6">Add New Patient</h2>
         <div className="flex justify-center">
-          <div className="items-center inline-block w-300 border-t-[3px] border-red-dark" />
+          <div className="items-center inline-block w-300 border-t-[3px] border-green-dark" />
         </div>
 
         <div className="relative">
@@ -323,7 +323,7 @@ const PatientRegister = ({ onClose }) => {
         </div>
         <div className="flex gap-4">
           <button
-            className="bg-red h-10 w-40 uppercase text-white rounded-md"
+            className="bg-green h-10 w-40 uppercase text-white rounded-md"
             type="submit"
             disabled={loading}
           >

--- a/frontend/src/components/ProgressBar.jsx
+++ b/frontend/src/components/ProgressBar.jsx
@@ -4,13 +4,13 @@ export default function ProgressBar({ progress=0 }) {
 	
     return (
         <Progress.Root
-            className="relative h-5 w-70 overflow-hidden rounded-full bg-red-soft"
+            className="relative h-5 w-70 overflow-hidden rounded-full bg-green-soft"
             style={{ transform: "translateZ(0)" }} // Prevenir overflow em browsers como Safari
             value={progress}
             max={100}
         >
             <Progress.Indicator 
-                className="ease-[cubic-bezier(0.65, 0, 0.35, 1)] size-full bg-red transition-transform duration-[660ms]"
+                className="ease-[cubic-bezier(0.65, 0, 0.35, 1)] size-full bg-green transition-transform duration-[660ms]"
 				style={{ transform: `translateX(-${100 - progress}%)` }}
             />
         </Progress.Root>

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,6 +1,6 @@
 import { Navigate } from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
-import api from "../api";
+import api, { useMockApi } from "../api";
 import { ACCESS_TOKEN, REFRESH_TOKEN } from "../constants";
 import { useState, useEffect } from "react";
 
@@ -8,6 +8,10 @@ function ProtectedRoute({ children }) {
     const [isAuthorized, setIsAuthorized] = useState(null);
 
     useEffect(() => {
+        if (useMockApi) {
+            setIsAuthorized(true);
+            return;
+        }
         auth().catch(() => setIsAuthorized(false));
     }, []);
 

--- a/frontend/src/components/RecentPatients.jsx
+++ b/frontend/src/components/RecentPatients.jsx
@@ -34,13 +34,15 @@ const RecentPatients = () => {
                 </button>
             </div>
             <ul>
-                {patients.map((patient) => (
+                {patients.map((patient) => {
+                    const gender = patient.gender || patient.sex;
+                    return (
                     <li 
                         key={patient.id} 
-                        className={`${patient.status === 'EVALUATED' ? 'bg-green-200' : patient.status === 'PENDING' ? 'bg-red-soft' : 'bg-orange-200'} mt-4 rounded-lg p-4 shadow-md flex items-center gap-4`}
-                    >                        <div className='border-2 border-red rounded-full overflow-clip w-14 h-14'>
+                        className={`${patient.status === 'EVALUATED' ? 'bg-green-200' : patient.status === 'PENDING' ? 'bg-green-soft' : 'bg-orange-200'} mt-4 rounded-lg p-4 shadow-md flex items-center gap-4`}
+                    >                        <div className='border-2 border-green rounded-full overflow-clip w-14 h-14'>
                             <img
-                                src={patient.gender === 'M' ? userMen : patient.gender === 'F' ? userWomen : patient.gender === 'O' ? userOther : userPatient}
+                                src={gender === 'M' ? userMen : gender === 'F' ? userWomen : gender === 'O' ? userOther : userPatient}
                                 alt={patient.name}
                                 role='img'
                                 className='w-full h-full object-cover'
@@ -63,7 +65,7 @@ const RecentPatients = () => {
                             <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24"><path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m10 17l5-5m0 0l-5-5"></path></svg>
                         </button>
                     </li>
-                ))}
+                )})}
             </ul>
         </div>
     );

--- a/frontend/src/components/ReportPDF.jsx
+++ b/frontend/src/components/ReportPDF.jsx
@@ -10,7 +10,7 @@ const styles = StyleSheet.create({
   },
   header: {
     marginBottom: 10,
-    borderBottom: '1.5 solid #B54A4A',
+    borderBottom: '1.5 solid #2F7D5D',
     paddingBottom: 5
   },
   title: {
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     marginBottom: 3,
-    color: '#B54A4A',
+    color: '#2F7D5D',
     letterSpacing: 0.3
   },
   subtitle: {
@@ -34,16 +34,16 @@ const styles = StyleSheet.create({
   patientInfo: {
     marginBottom: 10,
     padding: 7,
-    backgroundColor: '#FFEAEA',
+    backgroundColor: '#E6F6EA',
     borderRadius: 3,
-    border: '1 solid #EDD3D2'
+    border: '1 solid #D3EBD7'
   },
   sectionTitle: {
     fontSize: 9.5,
     fontWeight: 'bold',
     marginTop: 6,
     marginBottom: 4,
-    color: '#B54A4A',
+    color: '#2F7D5D',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     borderBottom: '1 solid #E8E8E8',
@@ -62,9 +62,9 @@ const styles = StyleSheet.create({
   conclusion: {
     marginTop: 6,
     padding: 7,
-    backgroundColor: '#F0F0F0',
+    backgroundColor: '#F2FBF4',
     borderRadius: 3,
-    border: '1 solid #D9D9D9'
+    border: '1 solid #D3EBD7'
   },
   signature: {
     marginTop: 12,
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
   },
   findingBullet: {
     fontSize: 8.5,
-    color: '#B54A4A',
+    color: '#2F7D5D',
     marginRight: 4,
     marginTop: 1
   },
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
     lineHeight: 1.15
   },
   highlight: {
-    backgroundColor: '#FFD06A',
+    backgroundColor: '#CFF2D8',
     padding: 1,
     borderRadius: 1
   },
@@ -150,14 +150,22 @@ const styles = StyleSheet.create({
     bottom: 10,
     right: 18,
     color: '#727272'
+  },
+  reportSection: {
+    marginTop: 6,
+    padding: 6,
+    backgroundColor: '#E6F6EA',
+    borderRadius: 3,
+    border: '1 solid #D3EBD7'
   }
 });
 
-const ReportPDF = ({ data, patient, medico }) => {
+const ReportPDF = ({ data, patient, medico, reportText }) => {
   const hasCalcification = data.some(item => item.is_calcified);
   const calcifiedFrames = data.filter(item => item.is_calcified).length;
   const totalFrames = data.length;
-  const calcificationPercentage = totalFrames > 0 ? ((calcifiedFrames / totalFrames) * 100).toFixed(1) : 0;  const currentDate = new Date().toLocaleDateString('en-US', { 
+  const calcificationPercentage = totalFrames > 0 ? ((calcifiedFrames / totalFrames) * 100).toFixed(1) : 0;
+  const currentDate = new Date().toLocaleDateString('en-US', { 
     day: '2-digit', 
     month: '2-digit', 
     year: 'numeric' 
@@ -325,6 +333,13 @@ const ReportPDF = ({ data, patient, medico }) => {
 
       <View style={styles.divider} />
 
+      {reportText && (
+        <View style={styles.reportSection}>
+          <Text style={styles.sectionTitle}>OBSERVAÇÕES CLÍNICAS</Text>
+          <Text style={styles.paragraph}>{reportText}</Text>
+        </View>
+      )}
+
       {/* Conclusion */}
       <View style={styles.conclusion}>
         <Text style={styles.sectionTitle}>CONCLUSION</Text>
@@ -341,7 +356,7 @@ const ReportPDF = ({ data, patient, medico }) => {
       <View style={styles.signature}>
         <Text>____________________________________</Text>
         <Text style={{fontWeight: 'bold', marginTop: 6, fontSize: 10}}>
-          Dr. {medico.first_name} {medico.last_name}
+          Dr. {medico?.first_name || 'Médico'} {medico?.last_name || ''}
         </Text>
         <Text style={{fontSize: 9, marginTop: 2}}>Cardiologist</Text>
         <Text style={{fontSize: 7, marginTop: 8, color: '#727272'}}>

--- a/frontend/src/components/UploadDicomFiles.jsx
+++ b/frontend/src/components/UploadDicomFiles.jsx
@@ -136,19 +136,19 @@ export default function UploadDicomFile({ patientId, reloadTable }) {
               </div>
               <p>{dicomFiles.name}</p>
               <button 
-                className='bg-red min-w-24 h-8 text-white rounded-md cursor-pointer grid place-items-center' 
+                className='bg-green min-w-24 h-8 text-white rounded-md cursor-pointer grid place-items-center' 
                 onClick={handleUploadFiles}
                 type='submit'
               >
                 {loadingUpload ? (
-                  <span role='status' className='relative z-5 size-4 rounded-full border-3 border-gray-pale border-t-red-dark animate-spin' />
+                  <span role='status' className='relative z-5 size-4 rounded-full border-3 border-gray-pale border-t-green-dark animate-spin' />
                 ) : (
                   "Upload"
                 )}
               </button>
           </div>
         ) : (
-          <label className='flex gap-2 w-fit bg-red-dark rounded-lg py-1 px-4 mt-5 text-white cursor-pointer'>
+          <label className='flex gap-2 w-fit bg-green-dark rounded-lg py-1 px-4 mt-5 text-white cursor-pointer'>
             <svg xmlns='http://www.w3.org/2000/svg' width={22} height={22} viewBox='0 0 24 24'>
               <path fill='currentColor' d='M11 16V7.85l-2.6 2.6L7 9l5-5l5 5l-1.4 1.45l-2.6-2.6V16zm-5 4q-.825 0-1.412-.587T4 18v-3h2v3h12v-3h2v3q0 .825-.587 1.413T18 20z'></path>
             </svg>

--- a/frontend/src/hooks/useBatchValveDetection.js
+++ b/frontend/src/hooks/useBatchValveDetection.js
@@ -1,109 +1,132 @@
 import { useRef, useState } from 'react';
-import api from '../api'
+import api, { useMockApi } from '../api';
 
 export function useBatchValveDetection() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState({});
+  const progressRef = useRef({});
+  const sockets = useRef({});
 
-    const [isLoading, setIsLoading] = useState(false);
-    const [progress, setProgress] = useState({})
-    const progressRef = useRef({})
-    const sockets = useRef({})
+  const setAndTrackProgress = (newData) => {
+    for (const [imageName, updates] of Object.entries(newData)) {
+      if (!progressRef.current[imageName]) progressRef.current[imageName] = {};
+      progressRef.current[imageName] = {
+        ...progressRef.current[imageName],
+        ...updates,
+      };
+    }
+    setProgress({ ...progressRef.current });
+  };
 
-    const setAndTrackProgress = (newData) => {
-        for(const [imageName, updates] of Object.entries(newData)) {
-            if(!progressRef.current[imageName])
-                progressRef.current[imageName] = {}
-            progressRef.current[imageName] = {
-                ...progressRef.current[imageName],
-                ...updates,
-            }
-        }
-        setProgress({ ...progressRef.current })
+  const startDetection = async (images, bboxs) => {
+    if (!images || images.length == 0) return;
+    setIsLoading(true);
+    setProgress({});
+
+    if (useMockApi) {
+      const result = {};
+      images.forEach((image, idx) => {
+        result[image.name] = {
+          status: 'SUCCESS',
+          progress: 100,
+          phase: 'Mock results ready',
+          results: {
+            bbox: [90 + idx * 5, 75 + idx * 4, 240 + idx * 5, 200 + idx * 4],
+            binary_classification: idx % 2 === 0,
+            confidence: 0.76,
+          },
+        };
+      });
+      setAndTrackProgress(result);
+      setIsLoading(false);
+      return result;
     }
 
-    const startDetection = async (images, bboxs) => {
-        if(!images || images.length == 0) return
-        setIsLoading(true)
-        setProgress({})
-        try {
+    try {
+      const formData = new FormData();
 
-            const formData = new FormData()
+      // Faz fetch de todas as imagens do batch e adiciona-as ao formulário
+      await Promise.all(
+        images.map(async ({ name, url }, idx) => {
+          try {
+            const imageFetch = await fetch(url);
+            if (!imageFetch.ok) throw new Error(`Erro no fetch da imagem ${name}`);
+            const blob = await imageFetch.blob();
+            formData.append('images', blob, name);
+            formData.append('bboxs', JSON.stringify(bboxs[idx] || {}));
+          } catch (error) {
+            console.error(`Erro ao processar ${name}:`, error);
+            throw error;
+          }
+        })
+      );
 
-            // Faz fetch de todas as imagens do batch e adiciona-as ao formulário
-            await Promise.all(
-                images.map(async ({ name, url }, idx) => {
-                    try {
-                        const imageFetch = await fetch(url);
-                        if(!imageFetch.ok) throw new Error(`Erro no fetch da imagem ${name}`)
-                        const blob = await imageFetch.blob();
-                        formData.append('images', blob, name)
-                        formData.append('bboxs', JSON.stringify(bboxs[idx] || {}))
-                    } catch (error) {
-                        console.error(`Erro ao processar ${name}:`, error);
-                        throw error;
-                    }
-                })
-            );
+      // Enviar para a view de identificação da válvula do Django
+      const response = await api.post(
+        import.meta.env.VITE_API_URL + '/api/model/valve-batch/',
+        formData
+      );
+      if (response.status != 202) throw new Error('Error initializing the model prediction.');
+      const batchId = response.data.task_id;
 
-            // Enviar para a view de identificação da válvula do Django
-            const response = await api.post(import.meta.env.VITE_API_URL + '/api/model/valve-batch/', formData)
-            if(response.status != 202) throw new Error('Error initializing the model prediction.')
-            const batchId = response.data.task_id;
-            
-            // Criação de uma conexão WebSocket para ir recebendo o progresso e os resultados
-            const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${batchId}/`);
-            console.log("Conectado ao WebSocket para o batchId:", batchId);
+      // Criação de uma conexão WebSocket para ir recebendo o progresso e os resultados
+      const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${batchId}/`);
+      console.log('Conectado ao WebSocket para o batchId:', batchId);
 
-            // A Promise impede que o fluxo do componente continue até ter um resolve
-            return new Promise((resolve) => {
-                socket.onmessage = function(event) {
-                    const data = JSON.parse(event.data);
-                    console.log("Mensagem recebida do WebSocket:", data);
-                    if(data.image_name === undefined) console.warn("Mensagem recebida sem image_name:", data);
+      // A Promise impede que o fluxo do componente continue até ter um resolve
+      return new Promise((resolve) => {
+        socket.onmessage = function (event) {
+          const data = JSON.parse(event.data);
+          console.log('Mensagem recebida do WebSocket:', data);
+          if (data.image_name === undefined)
+            console.warn('Mensagem recebida sem image_name:', data);
 
-                    setAndTrackProgress({
-                        [data.image_name]: {
-                            status: data.status,
-                            progress: data.progress,
-                            phase: data.phase,
-                            results: data.results,
-                            error: data.error,
-                        }
-                    })
+          setAndTrackProgress({
+            [data.image_name]: {
+              status: data.status,
+              progress: data.progress,
+              phase: data.phase,
+              results: data.results,
+              error: data.error,
+            },
+          });
 
-                    const allDone = Object.values(progressRef.current).every(
-                        (item) => Object.keys(progressRef.current).length === images.length && (item?.status === 'SUCCESS' || item?.status === 'FAILURE')
-                    )
+          const allDone = Object.values(progressRef.current).every(
+            (item) =>
+              Object.keys(progressRef.current).length === images.length &&
+              (item?.status === 'SUCCESS' || item?.status === 'FAILURE')
+          );
 
-                    console.log(progressRef.current)
-                    
-                    if(allDone) {
-                        socket.close()
-                        setIsLoading(false)
-                        resolve(progressRef.current)
-                    }
-                }
-                socket.onerror = (error) => { 
-                    socket.close();
-                    setIsLoading(false);
-                    throw error;
-                };
-                socket.onclose = () => {
-                    console.log("Conexão WebSocket fechada.");
-                };
+          console.log(progressRef.current);
 
-                sockets.current[batchId] = socket;
-            });
-        } catch(error) { 
-            setIsLoading(false)
-            throw error 
-        }
+          if (allDone) {
+            socket.close();
+            setIsLoading(false);
+            resolve(progressRef.current);
+          }
+        };
+        socket.onerror = (error) => {
+          socket.close();
+          setIsLoading(false);
+          throw error;
+        };
+        socket.onclose = () => {
+          console.log('Conexão WebSocket fechada.');
+        };
+
+        sockets.current[batchId] = socket;
+      });
+    } catch (error) {
+      setIsLoading(false);
+      throw error;
     }
+  };
 
-    const cancelDetection = () => {
-        Object.values(sockets.current).forEach((socket) => socket.close())
-        sockets.current = {}
-        setIsLoading(false)
-    }
+  const cancelDetection = () => {
+    Object.values(sockets.current).forEach((socket) => socket.close());
+    sockets.current = {};
+    setIsLoading(false);
+  };
 
-    return { isLoading, progress, startDetection, cancelDetection }
+  return { isLoading, progress, startDetection, cancelDetection };
 }

--- a/frontend/src/hooks/useCalciumDetection.js
+++ b/frontend/src/hooks/useCalciumDetection.js
@@ -1,81 +1,96 @@
 import { useState } from 'react';
-import api from '../api'
+import api, { useMockApi } from '../api';
 
 export function useCalciumDetection() {
+  const [progress, setProgress] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
 
-    const [progress, setProgress] = useState(0);
-    const [isLoading, setIsLoading] = useState(false);
-
-    /**
-     * Inicia a deteção de cálcio na válvula aórtica. Aceita a imagem inteira + retângulo ou imagem recortada
-     * Ou seja, se bbox for recebido (coordenadas do retângulo), então a task vai considerar que a imagem recebida é a imagem INTEIRA (e sem retângulo)
-     * E se bbox NÃO for recebido, então significa que a imagem recebida já está recortada (não é preciso as coordenadas) porque a imagem já está pronta
-     * @param {string} image - A imagem inteira ou recortada
-     * @param {Array} bbox - As coordenadas do retângulo (se existirem). Estão no formato [x, y, width, height]
-     * @returns {Promise} - Só retorna quando os resultados ("Com cálcio" ou "Sem cálcio") forem recebidos
-     */
-    const startDetection = async (image, bbox) => {
-        if(!image) return
-        setIsLoading(true)
-        try {
-            // Converter a imagem num BLOB (formato binário)
-            let blob
-            if(image instanceof File) {
-                blob = image
-            } else if(image instanceof HTMLElement) {
-                const imageFetch = await fetch(image.src);
-                blob = await imageFetch.blob() 
-            } else {
-                throw new Error('The image sent is not valid.')
-            }
-            console.log('blob', blob)
-            
-            const formData = new FormData()
-            // Adicionar o BLOB ao formData, que será enviado no corpo da requisição
-            formData.append('image', blob)
-            // Se bbox existir, significa que a imagem ainda não está recortada (recorte + deteção), senão a imagem já está recortada (detetar cálcio apenas)
-            formData.append('action', bbox ? 'full' : 'detect_only')
-            // Se bbox existir, adiciona-o ao formData
-            bbox && formData.append('bbox', JSON.stringify(bbox))
-
-            // Enviar para a view de identificação da válvula do Django
-            const response = await api.post(import.meta.env.VITE_API_URL + '/api/model/calcium/', formData)
-            if(response.status != 202) throw new Error('Error initializing the model prediction.')
-            const taskId = response.data.task_id;
-            console.log("Task ID:", taskId);
-            
-            // Criação de uma conexão WebSocket para ir recebendo o progresso e os resultados
-            const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${taskId}/`);
-
-            // A Promise impede que o fluxo do componente continue até ter um resolve ou reject
-            return new Promise((resolve, reject) => {
-                socket.onmessage = function(event) {
-                    const data = JSON.parse(event.data);
-                    setProgress(data.progress || 0);
-                    console.log("Mensagem recebida do WebSocket:", data);
-                    const resultsReady = data.results !== undefined;
-                    if(resultsReady) {
-                        socket.close();
-                        data.results.binary_classification = Boolean(data.results.binary_classification)
-                        setTimeout(() => {
-                            setIsLoading(false);
-                            setProgress(0);
-                            resolve(data.results);
-                        }, 500) // Pequeno delay para garantir que o loading é removido antes de mostrar os resultados
-                    }
-                }
-                socket.onerror = (error) => { 
-                    socket.close();
-                    reject(error);
-                };
-                socket.onclose = () => {
-                    console.log("Conexão WebSocket fechada.");
-                };
-            });
-        } catch(error) { 
-            throw error 
-        }
+  /**
+   * Inicia a deteção de cálcio na válvula aórtica.
+   */
+  const startDetection = async (image, bbox) => {
+    if (!image) return;
+    if (useMockApi) {
+      setIsLoading(true);
+      setProgress(45);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          const binary = Math.random() > 0.5;
+          setProgress(100);
+          setIsLoading(false);
+          resolve({
+            binary_classification: binary,
+            confidence: binary ? 0.82 : 0.18,
+            is_calcification_generated: true,
+          });
+          setProgress(0);
+        }, 650);
+      });
     }
 
-    return { progress, isLoading, startDetection }
+    setIsLoading(true);
+    try {
+      // Converter a imagem num BLOB (formato binário)
+      let blob;
+      if (image instanceof File) {
+        blob = image;
+      } else if (image instanceof HTMLElement) {
+        const imageFetch = await fetch(image.src);
+        blob = await imageFetch.blob();
+      } else {
+        throw new Error('The image sent is not valid.');
+      }
+      console.log('blob', blob);
+
+      const formData = new FormData();
+      // Adicionar o BLOB ao formData, que será enviado no corpo da requisição
+      formData.append('image', blob);
+      // Se bbox existir, significa que a imagem ainda não está recortada (recorte + deteção), senão a imagem já está recortada (detetar cálcio apenas)
+      formData.append('action', bbox ? 'full' : 'detect_only');
+      // Se bbox existir, adiciona-o ao formData
+      bbox && formData.append('bbox', JSON.stringify(bbox));
+
+      // Enviar para a view de identificação da válvula do Django
+      const response = await api.post(
+        import.meta.env.VITE_API_URL + '/api/model/calcium/',
+        formData
+      );
+      if (response.status != 202) throw new Error('Error initializing the model prediction.');
+      const taskId = response.data.task_id;
+      console.log('Task ID:', taskId);
+
+      // Criação de uma conexão WebSocket para ir recebendo o progresso e os resultados
+      const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${taskId}/`);
+
+      // A Promise impede que o fluxo do componente continue até ter um resolve ou reject
+      return new Promise((resolve, reject) => {
+        socket.onmessage = function (event) {
+          const data = JSON.parse(event.data);
+          setProgress(data.progress || 0);
+          console.log('Mensagem recebida do WebSocket:', data);
+          const resultsReady = data.results !== undefined;
+          if (resultsReady) {
+            socket.close();
+            data.results.binary_classification = Boolean(data.results.binary_classification);
+            setTimeout(() => {
+              setIsLoading(false);
+              setProgress(0);
+              resolve(data.results);
+            }, 500); // Pequeno delay para garantir que o loading é removido antes de mostrar os resultados
+          }
+        };
+        socket.onerror = (error) => {
+          socket.close();
+          reject(error);
+        };
+        socket.onclose = () => {
+          console.log('Conexão WebSocket fechada.');
+        };
+      });
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  return { progress, isLoading, startDetection };
 }

--- a/frontend/src/hooks/usePatientScreening.js
+++ b/frontend/src/hooks/usePatientScreening.js
@@ -1,169 +1,144 @@
-import { useRef, useState } from "react"
-import api from "../api"
-import { useBatchProgressStore } from '../store/useBatchProgressStore'
+import { useRef, useState } from "react";
+import api, { useMockApi } from "../api";
+import { useBatchProgressStore } from '../store/useBatchProgressStore';
 
 export function usePatientScreening() {
+  const [loading, setLoading] = useState(false);
+  const [batches, setBatches] = useState({});
+  const progressRef = useRef({});
+  const sockets = useRef({});
+  const { activeBatches, removeBatch, setBatches: setBatchesGlobalState } = useBatchProgressStore();
 
-    const [loading, setLoading] = useState(false)
-    const [batches, setBatches] = useState({})
-    const progressRef = useRef({})
-    const sockets = useRef({})
-    const { activeBatches, removeBatch, setBatches: setBatchesGlobalState } = useBatchProgressStore();
+  const setAndTrackProgress = (task_id, updates) => {
+    progressRef.current[task_id] = {
+      ...progressRef.current[task_id],
+      ...updates,
+    };
+    setBatches({ ...progressRef.current });
+  };
 
-    const setAndTrackProgress = (task_id, updates) => {
-        progressRef.current[task_id] = {
-            ...progressRef.current[task_id],
-            ...updates,
+  const startScreening = async () => {
+    setLoading(true);
+    setBatches({});
+    try {
+      const response = await api.get('/api/model/patient-screening/');
+
+      if (response.status !== 202) throw new Error('Erro ao iniciar patient screening');
+
+      // Adiciona os batches ao estado global de progresso
+      setBatchesGlobalState(response.data.batches);
+      setLoading(false);
+      return batches;
+    } catch (error) {
+      setLoading(false);
+      throw error;
+    }
+  };
+
+  const connectPatientScreening = async () => {
+    if (useMockApi) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    // Atualiza os dados mais recentes dos batches
+    await fetchBatchProgress(activeBatches);
+
+    activeBatches.forEach(({ task_id, echo, patient, frame_id }) => {
+      if (sockets.current[task_id]) return; // Já está conectado
+
+      const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${task_id}/`);
+
+      if (!sockets.current) sockets.current = {};
+      sockets.current[task_id] = socket;
+
+      socket.onopen = () => {
+        console.log('Conectado ao WebSocket para o task_id:', task_id);
+        socket.send(JSON.stringify({ type: 'get_status' })); // Solicita o status atual da task
+      };
+
+      socket.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        console.log('Mensagem recebida do WebSocket:', data);
+        setAndTrackProgress(task_id, { ...data, echo, patient, frame_id });
+        if (data.status === 'SUCCESS' || data.status === 'FAILURE') {
+          socket.close();
+          removeBatch(task_id); // Remove o batch do estado global
         }
-        setBatches({ ...progressRef.current })
-    }
+      };
 
-    /**
-     * Inicia o processo de screening de pacientes.
-     * Faz uma requisição para o backend para iniciar o screening e atualiza o estado global de batches.
-     * Retorna o estado atual dos batches (ainda vazio, porque o backend processa de forma assíncrona).
-     */
-    const startScreening = async () => {
-        setLoading(true)
-        setBatches({})
-        try {
-            const response = await api.get('/api/model/patient-screening/')
-            
-            if(response.status !== 202) 
-                throw new Error("Erro ao iniciar patient screening", response.statusText)
+      socket.onerror = () => {
+        socket.close();
+        removeBatch(task_id);
+        delete sockets.current[task_id];
+      };
 
-            // Adiciona os batches ao estado global de progresso
-            setBatchesGlobalState(response.data.batches)
-            setLoading(false)
-            return batches
-        } catch(error) {
-            setLoading(false)
-            throw error
+      socket.onclose = () => {
+        removeBatch(task_id);
+        delete sockets.current[task_id];
+        if (Object.keys(sockets.current).length === 0) {
+          setLoading(false);
         }
-    }
+      };
+    });
+  };
 
-    /**
-     * Conecta WebSockets para todos os batches ativos e busca o progresso imediato via REST.
-     * Para cada batch, conecta ao WebSocket correspondente e solicita o status atual.
-     * Atualiza o estado local com o progresso mais recente, tanto via REST quanto via mensagens WebSocket.
-     */
-    const connectPatientScreening = async () => {
-        setLoading(true)
-        
-        // Atualiza os dados mais recentes dos batches
-        await fetchBatchProgress(activeBatches)
-
-        activeBatches.forEach(({ task_id, echo, patient, frame_id }) => {
-            if(sockets.current[task_id]) return // Já está conectado
-
-            const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${task_id}/`)
-
-            if (!sockets.current) sockets.current = {};
-            sockets.current[task_id] = socket;
-
-            socket.onopen = () => {
-                console.log("Conectado ao WebSocket para o task_id:", task_id)
-                socket.send(JSON.stringify({ type: 'get_status' })) // Solicita o status atual da task
-            }
-
-            socket.onmessage = (event) => {
-                const data = JSON.parse(event.data)
-                console.log("Mensagem recebida do WebSocket:", data)
-                setAndTrackProgress(task_id, { ...data, echo, patient, frame_id })
-                if(data.status === 'SUCCESS' || data.status === 'FAILURE') {
-                    socket.close()
-                    removeBatch(task_id) // Remove o batch do estado global
-                }
-            }
-
-            socket.onerror = () => {
-                socket.close()
-                removeBatch(task_id)
-                delete sockets.current[task_id]
-            }
-
-            socket.onclose = () => {
-                removeBatch(task_id)
-                delete sockets.current[task_id]
-                if (Object.keys(sockets.current).length === 0) {
-                    setLoading(false)
-                }
-            }
-        })
-    }
-
-    /**
-     * Busca o progresso imediato de todos os batches ativos via REST.
-     * Para cada batch, faz uma requisição ao backend para obter o progresso salvo no Redis.
-     * Atualiza o estado local e o progressRef com os dados mais recentes.
-     * Utilizada antes de conectar os WebSockets para garantir que o frontend mostre o progresso mais atualizado.
-     * @param {Object} batches - Dicionário de batches ativos.
-     */
-    const fetchBatchProgress = async (batches) => {
-        const updated = {}
-        await Promise.all(
-            Object.values(batches).map(async (batch) => {
-                try {
-                    const response = await api.get(
-                        `/api/model/patient-screening/status/${batch.task_id}/`
-                    )
-                    updated[batch.task_id] = { ...batch, ...response.data}
-                } catch(error) {
-                    updated[batch.task_id] = batch
-                }
-            })
-        )
-        setBatches(updated)
-        progressRef.current = updated
-    }
-
-    /**
-     * Envia os resultados finais do screening para o backend para serem salvos.
-     * Monta o payload com os dados de cada batch/frame e faz uma requisição POST.
-     * Limpa o estado local após o envio.
-     * @returns {Promise<Object>} - Dados retornados pelo backend após salvar os resultados.
-     */
-    const acceptPatientScreening = async () => {
-        const results = Object.entries(batches).map(([task_id, batch]) => {
-            const progress = progressRef.current[task_id]?.results || {}
-            return {
-                patient_id: batch.patient.id,
-                echo_id: batch.echo.id,
-                frame_id: batch.frame_id,
-                rect: progress.bbox,
-                is_calcified: progress.binary_classification,
-                classification: progress.classification,
-                confidence: parseFloat(progress.confidence) / 100,
-            }
-        })
-
+  const fetchBatchProgress = async (batches) => {
+    const updated = {};
+    await Promise.all(
+      Object.values(batches).map(async (batch) => {
         try {
-            const response = await api.post('/api/model/patient-screening/accept/', { results })
-            setBatches({})
-            return response.data
+          const response = await api.get(`/api/model/patient-screening/status/${batch.task_id}/`);
+          updated[batch.task_id] = { ...batch, ...response.data };
         } catch (error) {
-            console.error('Error accepting patient screening:', error)
+          updated[batch.task_id] = batch;
         }
-    }
+      })
+    );
+    setBatches(updated);
+    progressRef.current = updated;
+  };
 
-    /**
-     * Cancela todos os sockets WebSocket abertos e limpa o progresso local.
-     */
-    const cancelPatientScreening = () => {
-        Object.values(sockets.current).forEach(socket => socket.close())
-        sockets.current = {}
-        progressRef.current = {}
-        setBatches({})
-        setLoading(false)
-    }
+  const acceptPatientScreening = async () => {
+    const results = Object.entries(batches).map(([task_id, batch]) => {
+      const progress = progressRef.current[task_id]?.results || {};
+      return {
+        patient_id: batch.patient.id,
+        echo_id: batch.echo.id,
+        frame_id: batch.frame_id,
+        rect: progress.bbox,
+        is_calcified: progress.binary_classification,
+        classification: progress.classification,
+        confidence: parseFloat(progress.confidence) / 100,
+      };
+    });
 
-    return { 
-        loading, 
-        batches, 
-        activeBatches, 
-        startScreening, 
-        connectPatientScreening, 
-        acceptPatientScreening,
-        cancelPatientScreening,
+    try {
+      const response = await api.post('/api/model/patient-screening/accept/', { results });
+      setBatches({});
+      return response.data;
+    } catch (error) {
+      console.error('Error accepting patient screening:', error);
     }
+  };
+
+  const cancelPatientScreening = () => {
+    Object.values(sockets.current).forEach((socket) => socket.close());
+    sockets.current = {};
+    progressRef.current = {};
+    setBatches({});
+    setLoading(false);
+  };
+
+  return {
+    loading,
+    batches,
+    activeBatches,
+    startScreening,
+    connectPatientScreening,
+    acceptPatientScreening,
+    cancelPatientScreening,
+  };
 }

--- a/frontend/src/hooks/useValveDetection.js
+++ b/frontend/src/hooks/useValveDetection.js
@@ -1,71 +1,85 @@
 import { useState } from 'react';
-import api from '../api'
+import api, { useMockApi } from '../api';
 
 export function useValveDetection() {
+  const [progress, setProgress] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [socket, setSocket] = useState(null);
 
-    const [progress, setProgress] = useState(0);
-    const [isLoading, setIsLoading] = useState(false);
-    const [socket, setSocket] = useState(null);
-
-    const startDetection = async (image) => {
-        if(!image) return
-        setIsLoading(true)
-        try {
-
-            let blob
-            if(image instanceof File) {
-                blob = image
-            } else if(image instanceof HTMLElement) {
-                const imageFetch = await fetch(image.src);
-                blob = await imageFetch.blob() 
-            } else {
-                throw new Error('The image sent is not valid.')
-            }
-
-            const formData = new FormData()
-            formData.append('image', blob)
-
-            // Enviar para a view de identificação da válvula do Django
-            const response = await api.post(import.meta.env.VITE_API_URL + '/api/model/valve/', formData)
-            if(response.status != 202) throw new Error('Error initializing the model prediction.')
-            const taskId = response.data.task_id;
-            
-            // Criação de uma conexão WebSocket para ir recebendo o progresso e os resultados
-            const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${taskId}/`);
-            setSocket(socket);
-            // A Promise impede que o fluxo do componente continue até ter um resolve ou reject
-            return new Promise((resolve, reject) => {
-                socket.onmessage = function(event) {
-                    const data = JSON.parse(event.data);
-                    setProgress(data.progress || 0);
-                    console.log("Mensagem recebida do WebSocket:", data);
-                    const resultsReady = data.results !== undefined;
-                    if(resultsReady) {
-                        socket.close();
-                        setTimeout(() => {
-                            setIsLoading(false);
-                            setProgress(0);
-                            resolve(data.results);
-                        }, 500) // Pequeno delay para garantir que o loading é removido antes de mostrar os resultados
-                    }
-                }
-                socket.onerror = (error) => { 
-                    socket.close();
-                    reject(error);
-                };
-                socket.onclose = () => {
-                    console.log("Conexão WebSocket fechada.");
-                };
-            });
-        } catch(error) { 
-            throw error 
-        }
+  const startDetection = async (image) => {
+    if (!image) return;
+    if (useMockApi) {
+      setIsLoading(true);
+      setProgress(40);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          setProgress(100);
+          setIsLoading(false);
+          resolve({ bbox: [120, 90, 260, 210] });
+          setProgress(0);
+        }, 600);
+      });
     }
 
-    const cancelDetection = () => {
-        socket.close();
-        setIsLoading(false);
-    }
+    setIsLoading(true);
+    try {
+      let blob;
+      if (image instanceof File) {
+        blob = image;
+      } else if (image instanceof HTMLElement) {
+        const imageFetch = await fetch(image.src);
+        blob = await imageFetch.blob();
+      } else {
+        throw new Error('The image sent is not valid.');
+      }
 
-    return { progress, isLoading, startDetection, cancelDetection }
+      const formData = new FormData();
+      formData.append('image', blob);
+
+      // Enviar para a view de identificação da válvula do Django
+      const response = await api.post(
+        import.meta.env.VITE_API_URL + '/api/model/valve/',
+        formData
+      );
+      if (response.status != 202) throw new Error('Error initializing the model prediction.');
+      const taskId = response.data.task_id;
+
+      // Criação de uma conexão WebSocket para ir recebendo o progresso e os resultados
+      const socket = new WebSocket(import.meta.env.VITE_WEBSOCKET_URL + `model/${taskId}/`);
+      setSocket(socket);
+      // A Promise impede que o fluxo do componente continue até ter um resolve ou reject
+      return new Promise((resolve, reject) => {
+        socket.onmessage = function (event) {
+          const data = JSON.parse(event.data);
+          setProgress(data.progress || 0);
+          console.log('Mensagem recebida do WebSocket:', data);
+          const resultsReady = data.results !== undefined;
+          if (resultsReady) {
+            socket.close();
+            setTimeout(() => {
+              setIsLoading(false);
+              setProgress(0);
+              resolve(data.results);
+            }, 500); // Pequeno delay para garantir que o loading é removido antes de mostrar os resultados
+          }
+        };
+        socket.onerror = (error) => {
+          socket.close();
+          reject(error);
+        };
+        socket.onclose = () => {
+          console.log('Conexão WebSocket fechada.');
+        };
+      });
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  const cancelDetection = () => {
+    socket?.close?.();
+    setIsLoading(false);
+  };
+
+  return { progress, isLoading, startDetection, cancelDetection };
 }

--- a/frontend/src/mocks/exams.json
+++ b/frontend/src/mocks/exams.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": 101,
+    "patientId": 1,
+    "date": "2024-05-10",
+    "type": "Eco transtorácico",
+    "description": "Eco TTE 10/05/2024",
+    "status": "EVALUATED",
+    "uploaded_at": "2024-05-10T09:20:00Z",
+    "vo": 0.28,
+    "frames": ["/calcivision_logo.png", "/grid-texture.png", "/calcivision_logo.png"]
+  },
+  {
+    "id": 102,
+    "patientId": 1,
+    "date": "2024-06-15",
+    "type": "Eco transesofágico",
+    "description": "Eco TEE 15/06/2024",
+    "status": "EVALUATED",
+    "uploaded_at": "2024-06-15T10:20:00Z",
+    "vo": 0.72,
+    "frames": ["/grid-texture.png", "/calcivision_logo.png", "/grid-texture.png"]
+  },
+  {
+    "id": 201,
+    "patientId": 2,
+    "date": "2024-06-02",
+    "type": "Eco transtorácico",
+    "description": "Eco TTE 02/06/2024",
+    "status": "IN_PROGRESS",
+    "uploaded_at": "2024-06-02T08:45:00Z",
+    "vo": 0.41,
+    "frames": ["/calcivision_logo.png", "/grid-texture.png", "/calcivision_logo.png"]
+  },
+  {
+    "id": 202,
+    "patientId": 2,
+    "date": "2024-07-01",
+    "type": "Eco transtorácico",
+    "description": "Eco TTE 01/07/2024",
+    "status": "UNDER_REVIEW",
+    "uploaded_at": "2024-07-01T15:00:00Z",
+    "vo": 0.63,
+    "frames": ["/grid-texture.png", "/calcivision_logo.png", "/grid-texture.png"]
+  },
+  {
+    "id": 301,
+    "patientId": 3,
+    "date": "2024-05-22",
+    "type": "Eco transtorácico",
+    "description": "Eco TTE 22/05/2024",
+    "status": "PENDING",
+    "uploaded_at": "2024-05-22T11:15:00Z",
+    "vo": 0.19,
+    "frames": ["/calcivision_logo.png", "/grid-texture.png", "/calcivision_logo.png"]
+  }
+]

--- a/frontend/src/mocks/mockDb.js
+++ b/frontend/src/mocks/mockDb.js
@@ -1,0 +1,379 @@
+import patientsSeed from './patients.json';
+import examsSeed from './exams.json';
+import reportsSeed from './reports.json';
+
+const STORAGE_KEY = 'calciVisionMockDb';
+
+const defaultImageSettings = {
+  brightness: 1,
+  contrast: 1,
+  blur: 0,
+  zoom: 1,
+};
+
+const seedDb = () => ({
+  patients: patientsSeed,
+  exams: examsSeed,
+  reports: reportsSeed,
+  examSettings: {},
+});
+
+const readDb = () => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    return JSON.parse(stored);
+  }
+  const seeded = seedDb();
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
+  return seeded;
+};
+
+const writeDb = (db) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
+};
+
+const ensureExamSettings = (db, examId) => {
+  if (!db.examSettings[examId]) {
+    db.examSettings[examId] = {
+      classificationOverride: null,
+      classificationConfirmed: false,
+      validated: false,
+      imageSettings: { ...defaultImageSettings },
+      reportText: '',
+      reportUpdatedAt: null,
+    };
+  }
+  return db.examSettings[examId];
+};
+
+const ensureExamFrames = (db, exam) => {
+  if (exam.framesData) {
+    return exam.framesData;
+  }
+  const frames = (exam.frames || ['/calcivision_logo.png']).map((imageUrl, index) => ({
+    id: `${exam.id}-${index + 1}`,
+    image_url: imageUrl,
+    data: [
+      {
+        x: 80 + index * 12,
+        y: 70 + index * 8,
+        width: 110,
+        height: 90,
+        is_annotation_generated: true,
+        is_calcified: exam.vo >= 0.66 ? 1 : 0,
+        confidence: Math.round(exam.vo * 100),
+        is_calcification_generated: true,
+      },
+    ],
+  }));
+  exam.framesData = frames;
+  return frames;
+};
+
+const buildPatientPayload = (db, patient) => {
+  const exams = db.exams
+    .filter((exam) => exam.patientId === patient.id)
+    .sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  const echocardiograms = exams.map((exam) => ({
+    id: exam.id,
+    description: exam.description,
+    status: exam.status,
+    uploaded_at: exam.uploaded_at,
+    date: exam.date,
+    type: exam.type,
+    vo: exam.vo,
+    frames: exam.frames,
+  }));
+
+  const reports = db.reports.filter((report) => report.patientId === patient.id);
+
+  return {
+    ...patient,
+    echocardiograms,
+    reports,
+    has_report: reports.length > 0,
+  };
+};
+
+export const mockDb = {
+  getPatients: () => {
+    const db = readDb();
+    return db.patients.map((patient) => buildPatientPayload(db, patient));
+  },
+  getPatient: (patientId) => {
+    const db = readDb();
+    const patient = db.patients.find((item) => item.id === Number(patientId));
+    if (!patient) return null;
+    return buildPatientPayload(db, patient);
+  },
+  getPatientExams: (patientId) => {
+    const db = readDb();
+    return db.exams.filter((exam) => exam.patientId === Number(patientId));
+  },
+  getExam: (examId) => {
+    const db = readDb();
+    return db.exams.find((exam) => exam.id === Number(examId));
+  },
+  getExamFrames: (patientId, examId) => {
+    const db = readDb();
+    const exam = db.exams.find(
+      (item) => item.patientId === Number(patientId) && item.id === Number(examId)
+    );
+    if (!exam) return [];
+    const frames = ensureExamFrames(db, exam);
+    writeDb(db);
+    return frames;
+  },
+  updateExamSubmission: ({ patientId, examId, results, completed, echoName }) => {
+    const db = readDb();
+    const exam = db.exams.find(
+      (item) => item.patientId === Number(patientId) && item.id === Number(examId)
+    );
+    if (!exam) return null;
+    if (echoName) {
+      exam.description = echoName;
+    }
+    exam.status = completed ? 'EVALUATED' : 'IN_PROGRESS';
+    const frames = ensureExamFrames(db, exam);
+    frames.forEach((frame, index) => {
+      if (results[index]) {
+        frame.data = results[index].rects?.length
+          ? results[index].rects.map((rect) => ({
+              ...rect,
+              is_annotation_generated: rect.is_annotation_generated ?? false,
+              is_calcified: results[index].is_calcified ? 1 : 0,
+              confidence: 92,
+              is_calcification_generated: results[index].generated_calcium ?? false,
+            }))
+          : [];
+      }
+    });
+    writeDb(db);
+    return exam;
+  },
+  getEchoResults: (patientId) => {
+    const db = readDb();
+    const exams = db.exams
+      .filter((exam) => exam.patientId === Number(patientId))
+      .sort((a, b) => new Date(b.date) - new Date(a.date));
+    const exam = exams[0];
+    if (!exam) return [];
+    const frames = ensureExamFrames(db, exam);
+    return frames.map((frame) => ({
+      frame: frame.id,
+      rects: frame.data?.[0]
+        ? {
+            x: frame.data[0].x,
+            y: frame.data[0].y,
+            width: frame.data[0].width,
+            height: frame.data[0].height,
+          }
+        : null,
+      is_calcified: frame.data?.[0]?.is_calcified === 1,
+      confidence: frame.data?.[0]?.confidence ?? null,
+    }));
+  },
+  getReports: (patientId) => {
+    const db = readDb();
+    return db.reports.filter((report) => report.patientId === Number(patientId));
+  },
+  createReport: ({ patientId, examId, reportText }) => {
+    const db = readDb();
+    const exam = db.exams.find((item) => item.id === Number(examId)) || db.exams.find((item) => item.patientId === Number(patientId));
+    const newReport = {
+      id: Date.now(),
+      patientId: Number(patientId),
+      patient: Number(patientId),
+      examId: Number(examId),
+      created_at: new Date().toISOString(),
+      reportText,
+      pdf_name: `report_${patientId}_${Date.now()}.pdf`,
+      pdf_size: 256,
+      report_url: 'https://example.com/report.pdf',
+      hasCalcification: exam ? exam.vo >= 0.66 : false,
+    };
+    db.reports.push(newReport);
+    writeDb(db);
+    return newReport;
+  },
+  deleteReport: (reportId) => {
+    const db = readDb();
+    db.reports = db.reports.filter((report) => report.id !== Number(reportId));
+    writeDb(db);
+  },
+  deletePatient: (patientId) => {
+    const db = readDb();
+    db.patients = db.patients.filter((patient) => patient.id !== Number(patientId));
+    db.exams = db.exams.filter((exam) => exam.patientId !== Number(patientId));
+    db.reports = db.reports.filter((report) => report.patientId !== Number(patientId));
+    writeDb(db);
+  },
+  createPatient: (patientData) => {
+    const db = readDb();
+    const newPatient = {
+      id: Date.now(),
+      name: patientData?.name || 'Novo paciente',
+      age: patientData?.age || 60,
+      sex: patientData?.sex || 'F',
+      email: patientData?.email || 'novo@example.com',
+      address: patientData?.address || 'Rua Simulada 1',
+      status: 'PENDING',
+      updated_at: new Date().toISOString(),
+      has_report: false,
+    };
+    db.patients.push(newPatient);
+    writeDb(db);
+    return newPatient;
+  },
+  addExam: (patientId, description) => {
+    const db = readDb();
+    const newExam = {
+      id: Date.now(),
+      patientId: Number(patientId),
+      date: new Date().toISOString().split('T')[0],
+      type: 'Eco transtorácico',
+      description: description || 'Novo ecocardiograma',
+      status: 'IN_PROGRESS',
+      uploaded_at: new Date().toISOString(),
+      vo: 0.45,
+      frames: ['/calcivision_logo.png', '/grid-texture.png', '/calcivision_logo.png'],
+    };
+    db.exams.push(newExam);
+    writeDb(db);
+    return newExam;
+  },
+  getExamSettings: (examId) => {
+    const db = readDb();
+    const settings = ensureExamSettings(db, examId);
+    writeDb(db);
+    return settings;
+  },
+  updateExamSettings: (examId, updates) => {
+    const db = readDb();
+    const settings = ensureExamSettings(db, examId);
+    db.examSettings[examId] = {
+      ...settings,
+      ...updates,
+      imageSettings: {
+        ...settings.imageSettings,
+        ...updates.imageSettings,
+      },
+    };
+    writeDb(db);
+    return db.examSettings[examId];
+  },
+  getMockUser: () => ({
+    id: 1,
+    first_name: 'Helena',
+    last_name: 'Carvalho',
+    medical_speciality: 'Cardiologia',
+  }),
+};
+
+const buildResponse = (data, status = 200) => Promise.resolve({ status, data });
+
+export const mockApi = {
+  get: (url) => {
+    if (url.startsWith('/api/patients-with-ecos/')) {
+      return buildResponse(mockDb.getPatients());
+    }
+    if (url.startsWith('/api/patients/')) {
+      return buildResponse(mockDb.getPatients());
+    }
+    if (url.startsWith('/api/reports/')) {
+      const patientId = url.split('/api/reports/')[1]?.split('/')[0];
+      return buildResponse(mockDb.getReports(patientId));
+    }
+    if (url.startsWith('/api/patient/') && url.endsWith('/echodata/')) {
+      const patientId = url.split('/api/patient/')[1]?.split('/')[0];
+      return buildResponse(mockDb.getEchoResults(patientId));
+    }
+    if (url.startsWith('/api/patient/') && url.includes('/echocardiogram/') && url.endsWith('/frames/')) {
+      const [patientId, examId] = url
+        .split('/api/patient/')[1]
+        .split('/echocardiogram/');
+      const examClean = examId.replace('/frames/', '');
+      return buildResponse(mockDb.getExamFrames(patientId, examClean));
+    }
+    if (url.startsWith('/api/patient/')) {
+      const patientId = url.split('/api/patient/')[1]?.split('/')[0];
+      return buildResponse(mockDb.getPatient(patientId));
+    }
+    if (url.startsWith('/api/model/patient-screening/status/')) {
+      return buildResponse({ status: 'SUCCESS', progress: 100, results: {} });
+    }
+    if (url.startsWith('/api/model/patient-screening/')) {
+      const patients = mockDb.getPatients();
+      const batches = patients.flatMap((patient) =>
+        patient.echocardiograms.slice(0, 1).map((echo) => ({
+          task_id: `${patient.id}-${echo.id}`,
+          patient,
+          echo,
+          frame_id: `${echo.id}-1`,
+        }))
+      );
+      return buildResponse({ batches }, 202);
+    }
+    if (url.startsWith('/me/')) {
+      return buildResponse(mockDb.getMockUser());
+    }
+    return buildResponse({});
+  },
+  post: (url, payload) => {
+    if (url.includes('/api/token/refresh/')) {
+      return buildResponse({ access: 'mock-access', refresh: 'mock-refresh' });
+    }
+    if (url.includes('/api/token/')) {
+      return buildResponse({ access: 'mock-access', refresh: 'mock-refresh' });
+    }
+    if (url.startsWith('/api/patient/create/')) {
+      return buildResponse(mockDb.createPatient(payload), 201);
+    }
+    if (url.includes('/echocardiogram/add/')) {
+      const patientId = url.split('/api/patient/')[1]?.split('/')[0];
+      return buildResponse(mockDb.addExam(patientId, payload?.get?.('description')), 201);
+    }
+    if (url.includes('/submit/')) {
+      const [patientId, examId] = url
+        .split('/api/patient/')[1]
+        .split('/echocardiogram/');
+      return buildResponse(
+        mockDb.updateExamSubmission({
+          patientId,
+          examId: examId.split('/')[0],
+          ...payload,
+        })
+      );
+    }
+    if (url.startsWith('/api/reports/') && url.endsWith('/create/')) {
+      const patientId = url.split('/api/reports/')[1]?.split('/')[0];
+      return buildResponse(mockDb.createReport({ patientId, reportText: payload?.reportText }));
+    }
+    if (url.startsWith('/api/model/')) {
+      return buildResponse({ task_id: 'mock-task' }, 202);
+    }
+    if (url.startsWith('/api/model/patient-screening/accept/')) {
+      return buildResponse({ ok: true });
+    }
+    return buildResponse({});
+  },
+  delete: (url) => {
+    if (url.includes('/echocardiogram/') && url.endsWith('/delete/')) {
+      return buildResponse({});
+    }
+    if (url.includes('/api/patient/') && url.endsWith('/delete/')) {
+      const patientId = url.split('/api/patient/')[1]?.split('/')[0];
+      mockDb.deletePatient(patientId);
+      return buildResponse({});
+    }
+    if (url.includes('/api/report/') && url.endsWith('/delete/')) {
+      const reportId = url.split('/api/report/')[1]?.split('/')[0];
+      mockDb.deleteReport(reportId);
+      return buildResponse({});
+    }
+    return buildResponse({});
+  },
+};
+
+export { defaultImageSettings };

--- a/frontend/src/mocks/patients.json
+++ b/frontend/src/mocks/patients.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": 1,
+    "name": "Ana Martins",
+    "sex": "F",
+    "age": 68,
+    "email": "ana.martins@example.com",
+    "address": "Rua do Carmo 12, Lisboa",
+    "status": "EVALUATED",
+    "updated_at": "2024-07-01T10:15:00Z",
+    "has_report": false
+  },
+  {
+    "id": 2,
+    "name": "João Costa",
+    "sex": "M",
+    "age": 72,
+    "email": "joao.costa@example.com",
+    "address": "Av. da Liberdade 85, Lisboa",
+    "status": "UNDER_REVIEW",
+    "updated_at": "2024-07-03T14:30:00Z",
+    "has_report": false
+  },
+  {
+    "id": 3,
+    "name": "Marta Silva",
+    "sex": "F",
+    "age": 59,
+    "email": "marta.silva@example.com",
+    "address": "Praça da República 4, Porto",
+    "status": "PENDING",
+    "updated_at": "2024-07-05T09:05:00Z",
+    "has_report": true
+  }
+]

--- a/frontend/src/mocks/reports.json
+++ b/frontend/src/mocks/reports.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 501,
+    "patientId": 3,
+    "patient": 3,
+    "examId": 301,
+    "created_at": "2024-05-23T09:30:00Z",
+    "reportText": "Relatório gerado automaticamente com base no exame e na variável objetiva.",
+    "pdf_name": "report_marta_silva_20240523.pdf",
+    "pdf_size": 248,
+    "report_url": "https://example.com/report_marta_silva_20240523.pdf",
+    "hasCalcification": false
+  }
+]

--- a/frontend/src/pages/AnalysisReview.jsx
+++ b/frontend/src/pages/AnalysisReview.jsx
@@ -50,7 +50,7 @@ export default function AnalysisReview() {
                     <div className="space-y-6">
                         {Object.entries(groupedTaks).map(([ patient, echos ]) =>
                             <Card key={patient} className="overflow-hidden">
-                                <div className="bg-red p-4 text-white">
+                                <div className="bg-green p-4 text-white">
                                     <h4 className="text-xl font-medium">{patient}</h4>
                                 </div>
                                 <div className="p-4">
@@ -78,7 +78,7 @@ export default function AnalysisReview() {
                                     content="Are you sure you want to stop all ongoing analysis? This will discard all changes made and can't be undone."
                                     onConfirm={() => cancelPatientScreening()}
                                 >
-                                    <button className="basis-48 flex items-center justify-center gap-2 bg-red-dark rounded-lg py-2 px-6 text-white">
+                                    <button className="basis-48 flex items-center justify-center gap-2 bg-green-dark rounded-lg py-2 px-6 text-white">
                                         <svg xmlns="http://www.w3.org/2000/svg" width={24} height={24} viewBox="0 0 24 24">
                                             <path fill="currentColor" d="m12 13.4l2.9 2.9q.275.275.7.275t.7-.275t.275-.7t-.275-.7L13.4 12l2.9-2.9q.275-.275.275-.7t-.275-.7t-.7-.275t-.7.275L12 10.6L9.1 7.7q-.275-.275-.7-.275t-.7.275t-.275.7t.275.7l2.9 2.9l-2.9 2.9q-.275.275-.275.7t.275.7t.7.275t.7-.275zm0 8.6q-2.075 0-3.9-.788t-3.175-2.137T2.788 15.9T2 12t.788-3.9t2.137-3.175T8.1 2.788T12 2t3.9.788t3.175 2.137T21.213 8.1T22 12t-.788 3.9t-2.137 3.175t-3.175 2.138T12 22"></path>
                                         </svg>
@@ -92,7 +92,7 @@ export default function AnalysisReview() {
                                         content="Are you sure you want reject all changes?"
                                         onConfirm={() => cancelPatientScreening()}
                                     >
-                                        <button className="grid place-items-center basis-36 border-red border-2 rounded-lg py-2 text-gray-dark">
+                                        <button className="grid place-items-center basis-36 border-green border-2 rounded-lg py-2 text-gray-dark">
                                             Discard
                                         </button>
                                     </AlertDialogMenu>
@@ -102,7 +102,7 @@ export default function AnalysisReview() {
                                         content='This action will save the results for all echocardiograms involved in the screening and mark them as reviewed. Are you sure you want to proceed?'
                                         onConfirm={() => acceptPatientScreening()}
                                     >
-                                        <button className="basis-36 flex items-center justify-center gap-2 bg-red-dark rounded-lg py-2 px-6 text-white">
+                                        <button className="basis-36 flex items-center justify-center gap-2 bg-green-dark rounded-lg py-2 px-6 text-white">
                                             <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} viewBox="0 0 16 16">
                                                 <path fill="currentColor" fillRule="evenodd" d="M2 2.5a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 .5.5V7h-1V3H3v10h2.005v1H2.5a.5.5 0 0 1-.5-.5zm11.994 6.832l-4.52 4.519a.5.5 0 0 1-.706 0l-2.51-2.51l.706-.708l2.157 2.157l4.166-4.166z" clipRule="evenodd" />
                                             </svg>
@@ -202,7 +202,7 @@ function FrameCard({ frame }) {
                         <ProgressBar 
                             progress={frame.progress}
                             className="h-2 bg-gray-pale rounded-full overflow-hidden"
-                            barClassName="bg-blue-700"
+                            barClassName="bg-green-700"
                         />
                     </div>
                 )}
@@ -212,7 +212,7 @@ function FrameCard({ frame }) {
                         <div className="flex justify-between">
                             <span className="text-sm text-gray-medium-dark">Binary Classification</span>
                             <span className="font-light">
-                                <div className='py-px px-2 bg-red text-white text-sm rounded-xl'>
+                                <div className='py-px px-2 bg-green text-white text-sm rounded-xl'>
                                     {frame.results.binary_classification === 1 ? 'Calcified' : 'Not Calcified'}
                                 </div>
                             </span>

--- a/frontend/src/pages/CompareExams.jsx
+++ b/frontend/src/pages/CompareExams.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import MainLayout from '../layouts/MainLayout';
+import { getPatientExams, getPatients } from '../api';
+
+const formatVo = (vo) => (vo !== null && vo !== undefined ? `${Math.round(vo * 100)}%` : 'N/A');
+
+const CompareExams = () => {
+  const { patientId, examIdA, examIdB } = useParams();
+  const [exams, setExams] = useState([]);
+  const [patientName, setPatientName] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const [patientExams, patients] = await Promise.all([
+        getPatientExams(patientId),
+        getPatients(),
+      ]);
+      setExams(patientExams || []);
+      const patient = patients.find((item) => item.id === Number(patientId));
+      setPatientName(patient?.name || 'Paciente');
+    };
+    fetchData();
+  }, [patientId]);
+
+  const examA = useMemo(
+    () => exams.find((exam) => exam.id === Number(examIdA)),
+    [exams, examIdA]
+  );
+  const examB = useMemo(
+    () => exams.find((exam) => exam.id === Number(examIdB)),
+    [exams, examIdB]
+  );
+
+  const voA = examA?.vo ?? 0;
+  const voB = examB?.vo ?? 0;
+  const diff = Math.abs(voB - voA);
+  const diffPercent = voA ? ((diff / voA) * 100).toFixed(1) : '0.0';
+  const trend = voB > voA ? 'pioria' : voB < voA ? 'melhoria' : 'estável';
+
+  return (
+    <MainLayout pageTitle="Comparar Exames">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="mb-2">Comparação longitudinal</h3>
+          <p className="text-gray-medium-dark">
+            {patientName} · Exames {examIdA} vs {examIdB}
+          </p>
+        </div>
+        <button
+          className="bg-green-dark text-white px-4 py-2 rounded"
+          onClick={() => navigate(-1)}
+        >
+          Voltar
+        </button>
+      </div>
+
+      <div className="grid lg:grid-cols-2 gap-6">
+        {[examA, examB].map((exam, index) => (
+          <div key={exam?.id || index} className="bg-white rounded-xl shadow p-5">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h4 className="text-lg font-semibold">Exame {index === 0 ? 'A' : 'B'}</h4>
+                <p className="text-sm text-gray-medium-dark">{exam?.description || '—'}</p>
+              </div>
+              <span className="px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700">
+                VO {formatVo(exam?.vo)}
+              </span>
+            </div>
+            <div className="aspect-video bg-green-soft rounded-lg flex items-center justify-center overflow-hidden">
+              {exam?.frames?.[0] ? (
+                <img src={exam.frames[0]} alt={`Frame do exame ${exam?.id}`} className="object-contain w-full h-full" />
+              ) : (
+                <span className="text-gray-medium-dark">Sem imagem</span>
+              )}
+            </div>
+            <div className="mt-4 text-sm text-gray-700">
+              <p><strong>Data:</strong> {exam?.date ? new Date(exam.date).toLocaleDateString('pt-PT') : '—'}</p>
+              <p><strong>Tipo:</strong> {exam?.type || '—'}</p>
+              <p><strong>Status:</strong> {exam?.status || '—'}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 bg-green-light rounded-xl p-6">
+        <h4 className="mb-4">Diferença de VO</h4>
+        <div className="grid md:grid-cols-3 gap-4 text-sm">
+          <div className="bg-white rounded-lg p-4">
+            <p className="text-gray-medium-dark">Diferença absoluta</p>
+            <p className="text-xl font-semibold">{(diff * 100).toFixed(1)}%</p>
+          </div>
+          <div className="bg-white rounded-lg p-4">
+            <p className="text-gray-medium-dark">Diferença percentual</p>
+            <p className="text-xl font-semibold">{diffPercent}%</p>
+          </div>
+          <div className="bg-white rounded-lg p-4 flex items-center gap-3">
+            <div className={`text-2xl ${trend === 'pioria' ? 'text-red' : trend === 'melhoria' ? 'text-green-dark' : 'text-gray-medium-dark'}`}>
+              {trend === 'pioria' ? '↑' : trend === 'melhoria' ? '↓' : '→'}
+            </div>
+            <div>
+              <p className="text-gray-medium-dark">Tendência</p>
+              <p className="text-lg font-semibold capitalize">{trend}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default CompareExams;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -62,12 +62,12 @@ const Home = () => {
             </div>
           </div>
           <div className="flex gap-4">
-            <div className="bg-red rounded-lg shadow-lg overflow-hidden">
+            <div className="bg-green rounded-lg shadow-lg overflow-hidden">
               <img src={AIDetectionImage} alt="AI Detection" role="img" className="object-cover w-full h-36" />
               <div className="px-6 py-4 text-white">
                 <h4 className="font-medium mb-2">AI Classification</h4>
                 <p className="font-light text-sm text-gray-soft">Automated Echocardiographic and MRI Annotation and Valve Calcification Detection Tool powered by our AI models.</p>
-                <div role="button" className="w-full max-w-30 m-auto py-2 mt-4 text-center rounded-sm text-lg font-medium bg-red-dark">
+                <div role="button" className="w-full max-w-30 m-auto py-2 mt-4 text-center rounded-sm text-lg font-medium bg-green-dark">
                   <Link to="/select_echo" target="_blank">
                     Start
                   </Link>
@@ -79,7 +79,7 @@ const Home = () => {
               <div className="px-6 py-4 text-gray-dark">
                 <h4 className="font-medium mb-2">Automatic Reports</h4>
                 <p className="font-light text-sm text-gray-dark">Generate complete echocardiographic reports regarding aortic valve clasification for any patient with our AI.</p>
-                <div role="button" className="w-full max-w-30 m-auto py-2 mt-4 text-center rounded-sm text-lg font-medium bg-red-dark text-white">
+                <div role="button" className="w-full max-w-30 m-auto py-2 mt-4 text-center rounded-sm text-lg font-medium bg-green-dark text-white">
                   <Link to="/reports" target="_blank">
                     Start
                   </Link>

--- a/frontend/src/pages/ManualAnnotation.jsx
+++ b/frontend/src/pages/ManualAnnotation.jsx
@@ -4,10 +4,10 @@ import AnnotationTool from '../components/AnnotationTool';
 import AnnotationToolMenu from '../components/AnnotationToolMenu';
 import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
-import api from '../api';
+import api, { getExamSettings, updateExamSettings } from '../api';
+import { defaultImageSettings } from '../mocks/mockDb';
 
 export default function ManualAnnotation() {
-  
   const [frames, setFrames] = useState([]);
   const [rects, setRects] = useState([]);
   const [currentFrame, setCurrentFrame] = useState(0);
@@ -17,22 +17,26 @@ export default function ManualAnnotation() {
   // A posição do retângulo dada pelo modelo
   const [predictedValveBoxes, setPredictedValveBoxes] = useState([]);
   const [calcificationStatus, setCalcificationStatus] = useState(null);
+  const [imageSettings, setImageSettings] = useState(defaultImageSettings);
 
   const [patient, setPatient] = useState(null);
+  const [exam, setExam] = useState(null);
   const { patientId, echoId } = useParams();
   const navigate = useNavigate();
 
   useEffect(() => {
     const fetchFrames = async () => {
       try {
-        const patientInfoResponse = await api.get(`/api/patient/${patientId}/`)
-        patientInfoResponse.status === 200 && setPatient(patientInfoResponse.data) 
-        
-        const echoFramesResponse = await api.get(`/api/patient/${patientId}/echocardiogram/${echoId}/frames/`)
-        const data = echoFramesResponse.data
+        const patientInfoResponse = await api.get(`/api/patient/${patientId}/`);
+        patientInfoResponse.status === 200 && setPatient(patientInfoResponse.data);
+
+        const echoFramesResponse = await api.get(
+          `/api/patient/${patientId}/echocardiogram/${echoId}/frames/`
+        );
+        const data = echoFramesResponse.data;
 
         // Atualiza os states principais
-        const formattedFrames = data.map(frame => ({
+        const formattedFrames = data.map((frame) => ({
           id: frame.id,
           url: frame.image_url,
           name: frame.image_url.split('/').pop(),
@@ -52,9 +56,9 @@ export default function ManualAnnotation() {
         );
 
         const formattedPredictedValveBoxes = data.map((frame) => {
-          frame.data 
-            ? frame.data.map(rect => {
-                if(rect.is_annotation_generated)
+          frame.data
+            ? frame.data.map((rect) => {
+                if (rect.is_annotation_generated)
                   return {
                     x: rect.x,
                     y: rect.y,
@@ -62,12 +66,12 @@ export default function ManualAnnotation() {
                     height: rect.height,
                     id: 'prediction',
                     is_annotation_generated: true,
-                  }
+                  };
               })
-            : []
-        })
+            : [];
+        });
 
-        const formattedCalcification = data.map(frame =>
+        const formattedCalcification = data.map((frame) =>
           frame.data?.[0] && frame.data[0].is_calcified !== null
             ? {
                 binary_classification: frame.data[0].is_calcified,
@@ -78,9 +82,9 @@ export default function ManualAnnotation() {
         );
 
         // Preenche o histórico com os dados de `data`
-        const formattedPredictionHistory = data.map(frame => {
+        const formattedPredictionHistory = data.map((frame) => {
           const rect = frame.data?.[0];
-          if(rect) {
+          if (rect) {
             return [
               {
                 rect: {
@@ -90,11 +94,13 @@ export default function ManualAnnotation() {
                   height: rect.height,
                   is_annotation_generated: Boolean(rect.is_annotation_generated),
                 },
-                results: frame.data[0].is_calcified !== null 
-                  ? {
-                    binary_classification: rect.is_calcified,
-                    confidence: rect.confidence,
-                  } : null,
+                results:
+                  frame.data[0].is_calcified !== null
+                    ? {
+                        binary_classification: rect.is_calcified,
+                        confidence: rect.confidence,
+                      }
+                    : null,
               },
             ];
           }
@@ -106,30 +112,53 @@ export default function ManualAnnotation() {
         setPredictedValveBoxes(formattedPredictedValveBoxes);
         setCalcification(formattedCalcification);
         setPredictionHistory(formattedPredictionHistory);
-        
-        formattedCalcification[currentFrame].binary_classification !== null &&
-          setCalcificationStatus(formattedCalcification[currentFrame].binary_classification === 1)
 
-      } catch(error) {
+        formattedCalcification[currentFrame]?.binary_classification !== null &&
+          formattedCalcification[currentFrame]?.binary_classification !== undefined &&
+          setCalcificationStatus(
+            formattedCalcification[currentFrame].binary_classification === 1
+          );
+      } catch (error) {
         if (error.response && (error.response.status === 403 || error.response.status === 404)) {
           navigate('/404');
         }
       }
-    }
-    fetchFrames()
+    };
+    fetchFrames();
   }, [patientId, echoId]);
+
+  useEffect(() => {
+    if (patient) {
+      const currentExam = patient.echocardiograms?.find((item) => item.id == echoId);
+      setExam(currentExam || null);
+    }
+  }, [patient, echoId]);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      const settings = await getExamSettings(echoId);
+      if (settings?.imageSettings) {
+        setImageSettings(settings.imageSettings);
+      }
+    };
+    loadSettings();
+  }, [echoId]);
+
+  const handleImageSettingsChange = async (nextSettings) => {
+    setImageSettings(nextSettings);
+    await updateExamSettings(echoId, { imageSettings: nextSettings });
+  };
 
   return (
     <MainLayout pageTitle={`${patient && patient.name} Analysis - CalciVision`}>
-
       {/* Annotation tool and menu */}
       <div className="w-full mb-8 grid grid-cols-[auto_1fr] grid-rows-1 gap-5 justify-items-start">
-        <AnnotationTool 
-          frames={frames} 
-          currentFrame={currentFrame} 
+        <AnnotationTool
+          frames={frames}
+          currentFrame={currentFrame}
           setCurrentFrame={setCurrentFrame}
-          rects={rects} 
-          setRects={setRects} 
+          rects={rects}
+          setRects={setRects}
           calcificationStatus={calcificationStatus}
           setCalcificationStatus={setCalcificationStatus}
           predictedValveBoxes={predictedValveBoxes}
@@ -138,20 +167,23 @@ export default function ManualAnnotation() {
           setCalcification={setCalcification}
           predictionHistory={predictionHistory}
           setPredictionHistory={setPredictionHistory}
+          imageSettings={imageSettings}
+          onImageSettingsChange={handleImageSettingsChange}
         />
-        <AnnotationToolMenu 
+        <AnnotationToolMenu
           frames={frames}
-          currentFrame={currentFrame} 
-          rects={rects} 
+          currentFrame={currentFrame}
+          rects={rects}
           calcificationStatus={calcificationStatus}
           setCalcificationStatus={setCalcificationStatus}
           calcification={calcification}
           setCalcification={setCalcification}
           predictionHistory={predictionHistory}
           patient={patient}
+          exam={exam}
           echoId={echoId}
         />
       </div>
     </MainLayout>
   );
-};
+}

--- a/frontend/src/pages/ManualAnnotationSetup.jsx
+++ b/frontend/src/pages/ManualAnnotationSetup.jsx
@@ -44,7 +44,7 @@ export default function ManualAnnotationSetup() {
                 <label htmlFor="patient">Patient</label>
                 <select 
                     name="patient" 
-                    className="px-4 py-2 border-2 border-red-dark w-fit"
+                    className="px-4 py-2 border-2 border-green-dark w-fit"
                     onChange={(e) => setSelectedPatientId(e.target.value)}
                     value={selectedPatientId}
                 >
@@ -62,7 +62,7 @@ export default function ManualAnnotationSetup() {
                     <label htmlFor="echocardiogram">Echocardiography</label>
                     <select
                         name="echocardiogram" 
-                        className="px-4 py-2 border-2 border-red-dark w-fit"
+                        className="px-4 py-2 border-2 border-green-dark w-fit"
                         onChange={(e) => setSelectedEchoId(e.target.value)}
                         value={selectedEchoId}
                     >
@@ -78,7 +78,7 @@ export default function ManualAnnotationSetup() {
 
             <button 
                 onClick={handleSubmit} 
-                className={`rounded-lg mt-8 py-1 px-4 text-m text-white ${selectedPatientId && selectedEchoId ? 'bg-red-dark' : 'bg-gray-medium'}`}
+                className={`rounded-lg mt-8 py-1 px-4 text-m text-white ${selectedPatientId && selectedEchoId ? 'bg-green-dark' : 'bg-gray-medium'}`}
             >
                 Continue
             </button>

--- a/frontend/src/pages/Patients.jsx
+++ b/frontend/src/pages/Patients.jsx
@@ -75,7 +75,7 @@ export default function Patients() {
       <div className='flex justify-start items-center mb-5'>
         <div className='mr-auto flex items-center gap-4'>
           <button
-            className='w-fit py-1 px-3 flex items-center gap-2 rounded-lg bg-red text-white'
+            className='w-fit py-1 px-3 flex items-center gap-2 rounded-lg bg-green text-white'
             onClick={() => setShowRegister(true)}
           >
             Add New Patient
@@ -100,7 +100,7 @@ export default function Patients() {
               )}
             onConfirm={handlePatientScreening}
           >
-            <button className='w-fit py-1 px-3 flex items-center gap-2 rounded-lg bg-red text-white'>
+            <button className='w-fit py-1 px-3 flex items-center gap-2 rounded-lg bg-green text-white'>
               Patient Screening
               <img className='w-5 h-5 object-contain' src={patientScreeningIcon} alt="Patient Screening" role="icon" />
             </button>

--- a/frontend/src/pages/Records.jsx
+++ b/frontend/src/pages/Records.jsx
@@ -52,7 +52,7 @@ const Records = () => {
   const handleDeleteReport = async (reportId) => {
     try {
       await deleteReport(reportId);
-      reloadTable();
+      fetchData();
     } catch (error) {
       console.error("Erro ao deletar relatório:", error);
       alert("Erro ao deletar relatório.");
@@ -88,7 +88,7 @@ const Records = () => {
         <p className="text-gray-600">Loading reports...</p>
       ) : filteredPatients.length > 0 ? (
         <table className="w-full table-fixed border border-collapse shadow-md rounded-lg">
-          <thead className="bg-red-dark text-white">
+          <thead className="bg-green-dark text-white">
             <tr>
               <th className="w-1/3 px-4 py-2 text-left">Report Name</th>
               <th className="w-1/10 px-4 py-2 text-left">Patient ID</th>
@@ -100,7 +100,7 @@ const Records = () => {
           </thead>
           <tbody>
             {filteredReports.map((report) => {
-              const reportPatient = patients.filter(patient => patient.id === report.patient)[0];
+              const reportPatient = patients.find(patient => patient.id === report.patient) || {};
 
               return (
                 <tr key={report.id} className="relative border-b hover:bg-gray-50">
@@ -113,7 +113,7 @@ const Records = () => {
                     </div>
                   </td>
                   <td className="text-sm p-3 text-left">{report.patient}</td>
-                  <td className="text-sm p-3 text-left">{reportPatient.name}</td>
+                  <td className="text-sm p-3 text-left">{reportPatient.name || '—'}</td>
                   <td className="text-sm p-3 text-left">{reportPatient.age || "N/A"}</td>
                   <td className="p-3 text-center">
                     <div className={`w-full py-3 rounded-lg text-sm ${report.hasCalcification ? "bg-red-100 text-red-800" : "bg-green-100 text-green-800"}`}>

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -72,7 +72,7 @@ const Reports = () => {
                 <div className="mb-8">
                     <h2 className="text-lg font-semibold mb-4">Select Patient</h2>
                     <div>
-                        <table className="w-full table-fixed bg-red-light shadow-md">
+                        <table className="w-full table-fixed bg-green-light shadow-md">
                             <thead className='border-b-2'>
                                 <tr>
                                     <th className='w-[9%] p-3 text-center'>Select</th>
@@ -147,7 +147,7 @@ const Reports = () => {
                                 </div>
 
                                 <button
-                                    className="bg-red text-white py-2 px-4 rounded"
+                                    className="bg-green text-white py-2 px-4 rounded"
                                     onClick={async () => {
                                         if (!selectedPatientId) {
                                             alert("Selecione um paciente!");

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2,11 +2,17 @@
 @import "tailwindcss";
 
 @theme {
-  --color-red: #B54A4A; /* Vermelho principal */
-  --color-red-dark: #832E2E;  /* Vermelho escuro */
+  --color-green: #2F7D5D; /* Verde principal */
+  --color-green-dark: #205941;  /* Verde escuro */
+  --color-green-light: #E6F6EA; /* Verde claro */
+  --color-green-pale: #D3EBD7;  /* Verde pálido */
+  --color-green-soft: #F2FBF4;  /* Verde suave */
+
+  --color-red: #D65C5C; /* Vermelho para alertas */
+  --color-red-dark: #A33A3A;  /* Vermelho escuro */
   --color-red-light: #FFEAEA; /* Vermelho claro */
-  --color-red-pale: #EDD3D2;  /* Vermelho pálido */
-  --color-red-soft: #FFCECE;  /* Vermelho suave */
+  --color-red-pale: #F7D8D8;  /* Vermelho pálido */
+  --color-red-soft: #FFEFEF;  /* Vermelho suave */
 
   --color-yellow: #FFD06A; /* Amarelo destaque */
 
@@ -16,8 +22,6 @@
   --color-gray-light: #E8E8E8;
   --color-gray-pale: #D9D9D9;
   --color-gray-soft: #F0F0F0;
-
-  --color-green: #A4D65E; /* Verde */
 }
 
 @layer base {
@@ -62,7 +66,7 @@
 
   color-scheme: light dark;
   color: rgba(0, 0, 0, 0.87);
-  background-color: #ffffff;
+  background-color: #F2FBF4;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -90,12 +94,12 @@
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
-    background-color: #ffffff;
+    background-color: #F2FBF4;
   }
 }
 
 .login-page {
-  background-color: #FFEAEA; /* Azul */
+  background-color: #F2FBF4;
   margin: 0;
   display: flex;
   height: 100vh;
@@ -118,11 +122,10 @@
 }
 
 .swiper-button-prev, .swiper-button-next {
-  color: var(--color-red-pale) !important
+  color: var(--color-green-pale) !important
 }
 
 /* interpolate-size é uma propriedade recente que ainda não é suportada pelo React */
 .patient-row-menu {
   interpolate-size: allow-keywords;
 }
-

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,7 +3,7 @@
 export default {
     content: [
         "./index.html",
-        "./src//*.{js,ts,jsx,tsx}",
+        "./src/**/*.{js,ts,jsx,tsx}",
     ],
     theme: {
         extend: {},

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
       "@components": path.resolve(__dirname, "./src/components"),
       "@assets": path.resolve(__dirname, "./src/assets"),
-      "@images": path.resolve(__dirname, "../src/assets/img")
+      "@images": path.resolve(__dirname, "./src/assets/img")
     }
   },
   server: {


### PR DESCRIPTION
### Motivation
- Provide a fully frontend-driven prototype (no backend required) so all key workflows can be demonstrated with simulated data and local persistence. 
- Add VO (Variável Objetiva) and risk visualization, a comparison flow, image adjustment tools and report generation to showcase core product value.
- Apply a consistent green visual identity across the app and PDF output for better UX and alignment with the new theme.

### Description
- Mock mode and mock DB: add `VITE_USE_MOCKS=true` and a `/src/mocks` layer with `patients.json`, `exams.json`, `reports.json` and `mockDb.js` providing seeded data and localStorage persistence, and wire `src/api.js` to fall back to `mockApi`/`mockDb` when mocks are enabled. 
- Exam history / VO: list exams on patient rows with VO values and colored risk badges (green/orange/red) and an info tooltip explaining VO; the PatientList/Echocardiograms table was extended to support selecting two exams to compare. 
- Compare page: add new route `/patients/:patientId/compare/:examIdA/:examIdB` and `CompareExams.jsx` to show side-by-side frames, VO values, absolute/percentage differences and a trend indicator. 
- Annotation & image tools: add sliders for brightness/contrast/blur/zoom in `AnnotationTool.jsx` with state persisted via `getExamSettings`/`updateExamSettings` (mocked), hook updates to detection hooks to return mocked results when mock mode is active, and small robustness fixes (pointer defaults, null checks). 
- Valve classification & validation & reports: generate automatic classification from VO, allow user confirm/override classification and validate detections (stored in exam settings), add report template generation/editing and export via updated `ReportPDF.jsx` (now accepts `reportText` and uses green palette). 
- Theming: update global styles (`src/styles/global.css`), Tailwind config and many components to use green tokens (backgrounds, buttons, badges, progress bars, PDF colors). 
- Vite fix: correct `@images` alias path in `vite.config.js` so image imports resolve. 

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and confirmed Vite served the app (server ready). (succeeded)
- Automated UI smoke: ran a Playwright script that opened `http://127.0.0.1:5173/patients`, waited for network idle and produced a screenshot of the patients/history UI (`artifacts/patients-history.png`). (succeeded)
- Verified mock mode by enabling `VITE_USE_MOCKS=true` in the added `frontend/.env` and confirming patient/exam/report flows (list, annotation page loading frames from mock data, compare page rendering) using the running dev server. (manual/automated checks passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977728ce2ac8331ab6edc5c98bd2fa8)